### PR TITLE
fix: ship pi-kit shared runtime and fix memory packaging

### DIFF
--- a/.changeset/pi-kit-shared-runtime.md
+++ b/.changeset/pi-kit-shared-runtime.md
@@ -1,0 +1,19 @@
+---
+"@fradser/pi-agent-teams": patch
+"@fradser/pi-btw": patch
+"@fradser/pi-memory": patch
+"@fradser/pi-monitor": patch
+"@fradser/pi-recap": patch
+"@fradser/pi-utils": patch
+"@fradser/pi-vision": patch
+---
+
+Introduce `@fradser/pi-kit` as the shared internal runtime package and remove duplicated TUI, message, and model-selection helpers across consumers:
+
+- Spinner frames/interval (`PI_SPINNER_FRAMES`, `PI_SPINNER_INTERVAL_MS`) come from pi-kit in agent-teams, memory, recap, and vision.
+- The overlay/console theme style language (`createPiThemeStyle`) comes from pi-kit in btw and agent-teams; `BtwOverlayStyle` aliases `PiThemeStyle`.
+- Message text extraction (`extractTextContent`) comes from pi-kit in btw, recap, vision, utils, and agent-teams.
+- Model selection (`parseModelRef`, `modelRef`, `modelLabel`, `sortModels`, `selectModelFromMenu`, `enterModelFromInput`) comes from pi-kit in memory, recap, and vision.
+- monitor's hand-rolled escape-key check now uses pi-tui's `matchesKey(data, Key.escape)`.
+
+Also fixes a packaging/loading bug in `@fradser/pi-memory`: `config.ts` moved into `extensions/` (it was outside the shipped `files` and the directory-glob the extension loader used), and the `pi.extensions` entry now points at `./extensions/inject-memory.ts` so pi loads exactly the factory file and treats `config.ts` as a helper module.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,67 @@
-# Pi Packages — Agent Guidelines
+# Repository Guidelines
 
-Monorepo of native **Pi** packages (`pi-packages/`). Each package under `packages/` is self-contained, installable via `pi install npm:@fradser/<name>` or a local path, and follows native Pi conventions — no Claude Code plugin artifacts.
+This is a pnpm monorepo of native Pi packages. Each directory under `packages/`
+is independently installable and follows Pi package conventions.
 
-## Layout & Tooling
+## Project Structure & Module Organization
 
-- `packages/<name>/` — one pi package each (`btw`, `code-context`, `lark`, `mattpocock`, `memory`, `monitor`, `agent-teams`, `utils`). (The former `git-agent` package now lives at `~/Developer/FradSer/git-agent/git-agent-pi-package`; the former `git`/`github` packages became pure skills in `~/Developer/FradSer/skills`.)
-- pnpm workspace at the root (`pnpm-workspace.yaml`); per-package deps live in `packages/<name>/node_modules`.
-- **Tests**: `python3 -m pytest packages/<name>/tests/`. BDD: write/update `.feature` files under `packages/<name>/features/` before behavior changes.
-- **Typecheck**: `npx tsc --noEmit --strict --skipLibCheck --target ES2022 --module ESNext --moduleResolution bundler --types "" packages/<name>/src/*.ts` (or `extensions/*.ts`).
-- Formatting: Biome, 2-space. Never edit `package.json`/`pyproject.toml` by hand — use `pnpm add` / `uv add`.
+- `packages/<name>/` contains the ten published packages: `agent-teams`, `btw`,
+  `context`, `keyboard`, `mattpocock`, `memory`, `monitor`, `recap`, `utils`, and
+  `vision`. Shared runtime code belongs in the internal `pi-kit` package when
+  that workspace package is available.
+- Package code lives in `src/` or `extensions/`; distributable skills,
+  procedures, and agents use their corresponding directories.
+- BDD scenarios are in `features/`; executable tests are in `tests/`.
+- Root release metadata lives in `.changeset/` and `.github/workflows/`.
+  `README.md` and `README.zh-CN.md` document the published package surface.
 
-## Pi package manifest
+## Build, Test, and Development Commands
 
+```bash
+pnpm install
+pnpm test
+npx tsc --noEmit -p tsconfig.extensions.json
+```
+
+`pnpm test` runs the Python test suite across `packages/`; run a single package
+with `python3 -m pytest packages/<name>/tests/`. Use `pnpm pack --dry-run`
+inside a package to inspect its published contents. There is no separate build
+step; Pi loads the TypeScript extensions and packaged resources directly.
+
+## Coding Style & Naming Conventions
+
+Use ESM TypeScript targeting Node 20 or newer, follow the surrounding file's
+indentation, and keep package names and command/tool names explicit and stable.
+Manifests need the `pi-package` keyword, a `pi` resource declaration, complete
+`files` entries, and Pi core packages as peer dependencies. Do not add Claude
+Code plugin artifacts or Claude-only skill frontmatter. Use package-manager
+commands such as `pnpm add` instead of hand-editing dependency manifests.
+
+## Shared Runtime: pi-kit
+
+Prefer the internal `@fradser/pi-kit` runtime for reusable helpers and shared
+Pi-package infrastructure before adding duplicate code to a package. It is a
+workspace runtime dependency, not a Pi package: consumer manifests use
+`"@fradser/pi-kit": "workspace:*"` under `dependencies`, never
+`peerDependencies`, and it has no `pi` manifest. Keep its dependency direction
+one-way: pi-kit may use Node built-ins, but must not import consumer packages.
+If the package is not present in the current checkout, do not invent a local
+replacement or external registry dependency; record the gap and coordinate the
+shared package first. Keep the release allowlist and pack/install checks in sync
+when pi-kit is introduced or changed.
+
+## Testing Guidelines
+
+Write or update a `.feature` scenario before behavior changes, then add tests
+under the package's `tests/` directory. Python tests use `pytest`; test modules
+follow `test_*.py`. Run the affected package tests and the strict TypeScript
+check before opening a pull request.
+
+## Pi UI and Extension Rules
+
+- Interactive popups use `ctx.ui.custom`; do not intercept terminal input globally.
+  Respect the established `packages/btw` wrapping, scrolling, theme, and cleanup
+  patterns. Keep passive widgets display-only.
 - `package.json`: `"keywords": ["pi-package"]`, `"pi": { "skills": [...], "extensions": [...] }`; extensions packages declare `"peerDependencies": { "@earendil-works/pi-coding-agent": "*" }`.
 - `files` must include everything that ships (`skills`/`extensions`/`procedures`/`references`/`scripts`).
 - **Never** add `.claude-plugin`, `${CLAUDE_PLUGIN_ROOT}`, or Claude-only skill frontmatter (`allowed-tools`, `user-invocable`, `argument-hint`, `model`). Skill frontmatter: `name`, `description`, optional `disable-model-invocation`.
@@ -39,6 +89,15 @@ Interactive extension UI mirrors `packages/btw/src/overlay.ts`:
 - `ctx.ui.custom` `render(width)` must fit the terminal: word-wrap with `wrapTextWithAnsi`, truncate with `truncateToWidth`.
 - pi negotiates the **Kitty keyboard protocol** (flags=7) with supporting terminals (Ghostty): Esc arrives as `\x1b[27u`, Shift+↑/↓ as `\x1b[1;2:1A`/`\x1b[1;2:1B` (event suffix). Match keys with CSI-u-aware regexes; filter releases with `isKeyRelease`.
 - Shared worker state between extension and child processes goes through a **shared JSON file** written atomically (tmp + rename); merge worker writes back on a poll/exit and never let a worker's write un-read a message the user already read.
+
+## Commits & Pull Requests
+
+Use the Conventional Commit style established in history, such as
+`feat:`, `fix(scope):`, `docs:`, `test(scope):`, `refactor:`, and
+`chore(release):`. Keep commits focused. Add a Changeset for a published
+package change. Pull requests should describe the affected packages, behavior
+and verification commands, and any release or migration impact. Update both
+root READMEs when the public package list or install commands change.
 
 ## Constraints
 

--- a/README.md
+++ b/README.md
@@ -6,32 +6,11 @@
 
 Native Pi packages for reusable skills, extensions, and workflow commands.
 
-## Using packages
-
-Skills use Pi's `/skill:<name>` command. Arguments after the command are appended to the skill text. Pi does not expand `$ARGUMENTS` or execute shell substitutions embedded in skill Markdown.
-
-Packages that manage interactive workflows use native commands such as `/keyboard`, `/recap`, `/memory`, `/btw`, and `/teammate` instead of skills.
-
-Released packages can be installed with an npm source:
-
-```bash
-pi install npm:pi-keyboard
-pi install npm:@fradser/pi-memory
-```
-
-Every package can be used from this checkout during development:
-
-```bash
-pi install /path/to/pi-packages/packages/<name>
-```
-
 ## Packages
 
 ### [`keyboard`](packages/keyboard/)
 
-Drives VIA and QMK mechanical keyboard RGB lighting to reflect Pi states, including white breathing for idle, blue breathing for thinking, green breathing for unread chat, yellow blinking for approval or questions, and red blinking for fatal errors. All updates run in memory without writing to EEPROM or Flash.
-
-**Command:** `/keyboard`, `/keyboard on`, `/keyboard off`, `/keyboard status`, `/keyboard test <state>`
+Controls VIA and QMK keyboard lighting to reflect Pi states, including idle, thinking, unread messages, approval prompts, and fatal errors.
 
 **Install:**
 
@@ -39,11 +18,9 @@ Drives VIA and QMK mechanical keyboard RGB lighting to reflect Pi states, includ
 pi install npm:pi-keyboard
 ```
 
----
-
 ### [`recap`](packages/recap/)
 
-Generates and displays a concise summary of current session progress above the TUI editor box. It persists across restarts and updates across parallel directory sessions.
+Displays a concise summary of session progress above the TUI editor and restores it across restarts.
 
 **Command:** `/recap`, `/recap on`, `/recap off`, `/recap language <lang>`, `/recap model <model>`
 
@@ -53,11 +30,9 @@ Generates and displays a concise summary of current session progress above the T
 pi install npm:@fradser/pi-recap
 ```
 
----
-
 ### [`vision`](packages/vision/)
 
-Bridges images to text for a text-only active model through a configured vision-capable Pi model. It preserves the original session attachment and adds visual analysis only to the transient provider context.
+Bridges images to a configured vision-capable model when the active Pi model only accepts text.
 
 **Command:** `/vision`, `/vision model provider/model`, `/vision on`, `/vision off`
 
@@ -67,11 +42,9 @@ Bridges images to text for a text-only active model through a configured vision-
 pi install npm:@fradser/pi-vision
 ```
 
----
-
 ### [`btw`](packages/btw/)
 
-Answers a side question in a read-only overlay without adding it to the current session history. The child Pi process may use `read`, `grep`, `find`, and `ls` to check the codebase, but cannot use `bash`, `edit`, or `write`.
+Answers side questions in a read-only overlay without adding them to the current session history.
 
 **Command:** `/btw <question>`
 
@@ -81,13 +54,11 @@ Answers a side question in a read-only overlay without adding it to the current 
 pi install npm:@fradser/pi-btw
 ```
 
----
-
 ### [`memory`](packages/memory/)
 
-Manages durable project memory with a `/memory` menu, auto-memory guidance, and background consolidation. The consolidation procedure runs in a separate child Pi process and keeps its raw work outside the active conversation.
+Manages durable project memory with a `/memory` menu, auto-memory guidance, and manual consolidation.
 
-**Commands:** `/memory`, `/consolidate`
+**Command:** `/memory`, `/consolidate`
 
 **Install:**
 
@@ -95,17 +66,11 @@ Manages durable project memory with a `/memory` menu, auto-memory guidance, and 
 pi install npm:@fradser/pi-memory
 ```
 
----
-
 ### [`monitor`](packages/monitor/)
 
-Runs a command in the background against an explicit result contract. It stores ordinary output outside model context and sends exactly one structured terminal result for success, failure, timeout, or a missing result.
+Runs background commands against an explicit result contract and reports one structured terminal result.
 
 **Tools:** `monitor_start`, `monitor_stop`
-
-**Skill:** `/skill:using-monitor`
-
-**Command:** `/monitor`
 
 **Install:**
 
@@ -113,13 +78,9 @@ Runs a command in the background against an explicit result contract. It stores 
 pi install npm:@fradser/pi-monitor
 ```
 
----
-
 ### [`utils`](packages/utils/)
 
-Adds commands for selecting a model thinking level and recovering interrupted work. It also provides multi-session registry synchronization and directs safe `git worktree add` invocations into `.pi/worktrees/`.
-
-**Commands:** `/effort`, `/continue`, `/sessions`
+Adds `/effort`, `/continue`, and `/sessions`, and redirects safe Git worktrees into `.pi/worktrees/`.
 
 **Install:**
 
@@ -127,39 +88,41 @@ Adds commands for selecting a model thinking level and recovering interrupted wo
 pi install npm:@fradser/pi-utils
 ```
 
----
-
 ### [`agent-teams`](packages/agent-teams/)
 
-Coordinates autonomous child Pi workers through a run-centric task graph and mailbox protocol. The team leader dispatches dependency-aware task graphs in one call, tracks progress, cancels or retries nodes, and inspects the full-screen console.
+Coordinates child Pi workers through dependency-aware task graphs, bounded concurrency, cancellation, retries, and a full-screen console.
 
-**Tools:** `teammate_run`, `teammate_status`, `teammate_cancel`, `teammate_retry`, `teammate_message`, `teammate_inbox`
+**Tools:** `teammate_run`, `teammate_cancel`, `teammate_retry`, `teammate_message`
 
 **Command:** `/teammate`
 
-**Availability:** install from this checkout. It is not currently released to npm.
+**Install:**
 
----
+```bash
+pi install npm:@fradser/pi-agent-teams
+```
 
 ### [`code-context`](packages/code-context/)
 
-Provides DeepWiki, Context7, and Exa retrieval tools, with clone and HTTP fetch workflows as fallbacks. The package uses direct REST calls rather than MCP sidecars.
+Provides DeepWiki, Context7, and Exa retrieval tools through native Pi extensions, with clone and HTTP fallbacks.
 
 **Skills:** `/skill:get-context`, `/skill:code-context`
 
-**Tools:** `context_deepwiki`, `context_context7`, `context_exa`
+**Install:**
 
-**Availability:** install from this checkout. It is not currently released to npm.
-
----
+```bash
+pi install npm:@fradser/pi-context
+```
 
 ### [`mattpocock`](packages/mattpocock/)
 
-A collection of Pi-adapted BDD, TDD, implementation, review, debugging, architecture, research, planning, handoff, teaching, and skill-writing workflows.
+Provides Pi-adapted BDD, TDD, implementation, review, debugging, architecture, research, planning, teaching, and skill-writing workflows.
 
-**Skills:** 27 individual skills, including `/skill:bdd`, `/skill:tdd`, `/skill:implement`, and `/skill:code-review`
+**Install:**
 
-**Availability:** install from this checkout. It is not currently released to npm.
+```bash
+pi install npm:pi-mattpocock
+```
 
 ## Development
 
@@ -168,7 +131,7 @@ pnpm install
 python3 -m pytest packages
 ```
 
-Each package keeps its behavior scenarios in `features/` and tests in `tests/`. Run the relevant strict TypeScript check after editing an extension:
+Each package keeps behavior scenarios in `features/` and tests in `tests/`. For an extension, run the relevant strict TypeScript check:
 
 ```bash
 npx tsc --noEmit --strict --skipLibCheck --target ES2022 \
@@ -176,22 +139,22 @@ npx tsc --noEmit --strict --skipLibCheck --target ES2022 \
   packages/<name>/{src,extensions}/*.ts
 ```
 
-Use `pnpm pack --dry-run` from an individual package to inspect the files that would ship.
+Use `pnpm pack --dry-run` from a package directory to inspect its published files.
 
 ## Adding a package
 
 1. Create `packages/<name>/`.
 2. Add a `package.json` with the `pi-package` keyword and an explicit `pi` resource manifest.
-3. Include every runtime resource in `files` and declare every imported Pi core package as a peer dependency.
+3. Include runtime resources in `files` and declare imported Pi core packages as peer dependencies.
 4. Write the BDD scenario under `features/` before implementation, then add executable tests.
-5. Install the package locally with `pi install /path/to/pi-packages/packages/<name>` and validate its package contents.
+5. Add a Changeset for a released package change.
 
 ## Publishing
 
-This repository publishes through Changesets and the GitHub Actions release workflow. Do not run recursive `pnpm publish` from the repository root.
+Releases use Changesets and the GitHub Actions workflow in `.github/workflows/release.yml`. Push changes to `main`, then merge the generated version PR. The workflow publishes the explicit package list through npm Trusted Publishing and skips versions already present in the npm registry, so partial runs can be retried safely.
 
-For a released package change, create a Changeset, push it to `main`, and merge the generated version PR. The release workflow publishes only its explicit package allowlist with npm trusted publishing. A new package needs its first npm publication and trusted-publishing setup before the workflow can publish later versions.
+New packages require one manual first publication and npm Trusted Publishing configuration before later versions can be released by GitHub Actions.
 
 ## License
 
-Each package declares the MIT license in its own manifest. The repository does not have a separate root license file.
+Each package is licensed under MIT.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,32 +6,11 @@
 
 面向 Pi 的原生包，用于复用 skills、extensions 和工作流命令。
 
-## 使用包
-
-Skill 使用 Pi 的 `/skill:<name>` 命令。命令后的参数会追加到 skill 文本。Pi 不会展开 `$ARGUMENTS`，也不会执行 skill Markdown 中嵌入的 shell 替换。
-
-管理交互式工作流的包使用 `/keyboard`、`/recap`、`/memory`、`/btw`、`/teammate` 等原生命令，而不是 skill。
-
-已发布的包可以使用 npm 源安装：
-
-```bash
-pi install npm:pi-keyboard
-pi install npm:@fradser/pi-memory
-```
-
-开发时，所有包都可以从当前 checkout 安装：
-
-```bash
-pi install /path/to/pi-packages/packages/<name>
-```
-
 ## 包列表
 
 ### [`keyboard`](packages/keyboard/)
 
-控制 VIA 和 QMK 机械键盘的 RGB 灯光以反映 Pi 的运行状态，包括空闲待命白色呼吸、思考运行蓝色呼吸、未读消息绿色呼吸、审批提问黄色闪烁以及致命异常红色闪烁。所有更新均在内存中执行，不写入 EEPROM 或 Flash。
-
-**命令：** `/keyboard`、`/keyboard on`、`/keyboard off`、`/keyboard status`、`/keyboard test <state>`
+控制 VIA 和 QMK 键盘灯光以反映 Pi 的运行状态，包括空闲、思考、未读消息、审批提问和致命异常。
 
 **安装：**
 
@@ -39,11 +18,9 @@ pi install /path/to/pi-packages/packages/<name>
 pi install npm:pi-keyboard
 ```
 
----
-
 ### [`recap`](packages/recap/)
 
-在 TUI 输入框上方生成并展示当前会话进展的精简回顾。支持在重启后恢复已保存摘要，并自动同步同一目录下的多会话进展。
+在 TUI 输入框上方显示会话进展摘要，并支持在重启后恢复。
 
 **命令：** `/recap`、`/recap on`、`/recap off`、`/recap language <lang>`、`/recap model <model>`
 
@@ -53,11 +30,9 @@ pi install npm:pi-keyboard
 pi install npm:@fradser/pi-recap
 ```
 
----
-
 ### [`vision`](packages/vision/)
 
-当当前模型仅支持文本时，通过已配置的 Pi 视觉模型将图片转换为文字。它保留原始会话附件，只将视觉分析加入瞬态 provider context。
+当当前 Pi 模型只接受文本时，将图片交给已配置的视觉模型进行分析。
 
 **命令：** `/vision`、`/vision model provider/model`、`/vision on`、`/vision off`
 
@@ -67,11 +42,9 @@ pi install npm:@fradser/pi-recap
 pi install npm:@fradser/pi-vision
 ```
 
----
-
 ### [`btw`](packages/btw/)
 
-在只读浮层中回答旁路问题，不会写入当前会话历史。子 Pi 进程可以使用 `read`、`grep`、`find` 和 `ls` 检查代码库，但不能使用 `bash`、`edit` 或 `write`。
+在只读浮层中回答旁路问题，不会把问题加入当前会话历史。
 
 **命令：** `/btw <question>`
 
@@ -81,11 +54,9 @@ pi install npm:@fradser/pi-vision
 pi install npm:@fradser/pi-btw
 ```
 
----
-
 ### [`memory`](packages/memory/)
 
-通过 `/memory` 菜单、自动记忆引导和后台整合管理持久化项目记忆。整合流程在独立的子 Pi 进程中执行，其原始工作内容不会进入当前对话。
+通过 `/memory` 菜单、自动记忆引导和手动整合管理持久化项目记忆。
 
 **命令：** `/memory`、`/consolidate`
 
@@ -95,17 +66,11 @@ pi install npm:@fradser/pi-btw
 pi install npm:@fradser/pi-memory
 ```
 
----
-
 ### [`monitor`](packages/monitor/)
 
-在后台按明确的结果契约运行命令。普通输出保留在模型 context 之外，并且仅在成功、失败、超时或缺失结果时发送一条结构化终态结果。
+按明确的结果契约在后台运行命令，并发送一条结构化终态结果。
 
 **工具：** `monitor_start`、`monitor_stop`
-
-**Skill：** `/skill:using-monitor`
-
-**命令：** `/monitor`
 
 **安装：**
 
@@ -113,13 +78,9 @@ pi install npm:@fradser/pi-memory
 pi install npm:@fradser/pi-monitor
 ```
 
----
-
 ### [`utils`](packages/utils/)
 
-增加选择模型 thinking level 和恢复中断工作的命令，提供跨会话注册表同步，并将安全的 `git worktree add` 调用定向到 `.pi/worktrees/`。
-
-**命令：** `/effort`、`/continue`、`/sessions`
+提供 `/effort`、`/continue` 和 `/sessions`，并将安全的 Git worktree 定向到 `.pi/worktrees/`。
 
 **安装：**
 
@@ -127,39 +88,41 @@ pi install npm:@fradser/pi-monitor
 pi install npm:@fradser/pi-utils
 ```
 
----
-
 ### [`agent-teams`](packages/agent-teams/)
 
-通过以 run 为核心的任务图和邮箱协议协调自治的子 Pi worker。Team leader 可以单次调用派发具有依赖关系的任务图、追踪进展、取消或重试节点，并打开全屏控制台。
+通过依赖关系任务图、并发限制、取消、重试和全屏控制台协调 Pi 子 worker。
 
-**工具：** `teammate_run`、`teammate_status`、`teammate_cancel`、`teammate_retry`、`teammate_message`、`teammate_inbox`
+**工具：** `teammate_run`、`teammate_cancel`、`teammate_retry`、`teammate_message`
 
 **命令：** `/teammate`
 
-**可用性：** 请从当前 checkout 安装。该包目前尚未发布到 npm。
+**安装：**
 
----
+```bash
+pi install npm:@fradser/pi-agent-teams
+```
 
 ### [`code-context`](packages/code-context/)
 
-提供 DeepWiki、Context7 和 Exa 检索工具，并以 clone 与 HTTP 抓取工作流作为兜底。该包直接调用 REST API，不使用 MCP sidecar。
+通过原生 Pi extension 提供 DeepWiki、Context7 和 Exa 检索工具，并支持 clone 与 HTTP 抓取兜底。
 
 **Skills：** `/skill:get-context`、`/skill:code-context`
 
-**工具：** `context_deepwiki`、`context_context7`、`context_exa`
+**安装：**
 
-**可用性：** 请从当前 checkout 安装。该包目前尚未发布到 npm。
-
----
+```bash
+pi install npm:@fradser/pi-context
+```
 
 ### [`mattpocock`](packages/mattpocock/)
 
-一组适配 Pi 的 BDD、TDD、实现、评审、调试、架构、调研、规划、交接、教学和 skill 编写工作流。
+提供适配 Pi 的 BDD、TDD、实现、评审、调试、架构、调研、规划、教学和 skill 编写工作流。
 
-**Skills：** 共 27 个独立 skill，包括 `/skill:bdd`、`/skill:tdd`、`/skill:implement` 和 `/skill:code-review`
+**安装：**
 
-**可用性：** 请从当前 checkout 安装。该包目前尚未发布到 npm。
+```bash
+pi install npm:pi-mattpocock
+```
 
 ## 开发
 
@@ -168,7 +131,7 @@ pnpm install
 python3 -m pytest packages
 ```
 
-每个包将行为场景放在 `features/`，测试放在 `tests/`。修改 extension 后，运行对应的严格 TypeScript 检查：\
+每个包将行为场景放在 `features/`，测试放在 `tests/`。修改 extension 后，运行对应的严格 TypeScript 检查：
 
 ```bash
 npx tsc --noEmit --strict --skipLibCheck --target ES2022 \
@@ -176,22 +139,22 @@ npx tsc --noEmit --strict --skipLibCheck --target ES2022 \
   packages/<name>/{src,extensions}/*.ts
 ```
 
-在单个 package 目录执行 `pnpm pack --dry-run` 可以检查将要发布的文件。
+在包目录执行 `pnpm pack --dry-run` 可以检查将要发布的文件。
 
 ## 添加包
 
 1. 创建 `packages/<name>/`。
 2. 添加包含 `pi-package` keyword 和明确 `pi` 资源声明的 `package.json`。
-3. 将所有运行时资源包含进 `files`，并将导入的 Pi 核心包声明为 peer dependency。
-4. 在实现前在 `features/` 下编写 BDD 场景，然后添加可执行测试。
-5. 使用 `pi install /path/to/pi-packages/packages/<name>` 本地安装该包并校验其内容。
+3. 将运行时资源包含进 `files`，并将导入的 Pi 核心包声明为 peer dependency。
+4. 在实现前于 `features/` 下编写 BDD 场景，然后添加可执行测试。
+5. 为已发布包的修改添加 Changeset。
 
 ## 发布
 
-本仓库通过 Changesets 和 GitHub Actions 发布工作流进行发布。不要在仓库根目录直接运行递归的 `pnpm publish`。
+发布使用 `.github/workflows/release.yml` 中的 Changesets 和 GitHub Actions 工作流。将修改推送到 `main`，然后合并生成的 version PR。工作流通过 npm Trusted Publishing 发布明确列出的包，并跳过 npm registry 中已经存在的版本，因此部分发布失败后可以安全重试。
 
-对于已发布包的修改，创建 Changeset，推送到 `main` 分支，并合并生成的 version PR。发布工作流仅通过 npm trusted publishing 发布白名单中指定的包。新增的包需要先完成首次 npm 手动发布与 trusted-publishing 信任配置，后续版本才能通过工作流自动发布。
+新包需要先手动完成一次首次发布并配置 npm Trusted Publishing，后续版本才能通过 GitHub Actions 发布。
 
 ## 许可证
 
-每个包在自己的清单中声明 MIT 许可证。本仓库不设单独的根许可证文件。
+每个包均使用 MIT 许可证。

--- a/packages/agent-teams/features/agent-teams.feature
+++ b/packages/agent-teams/features/agent-teams.feature
@@ -7,7 +7,7 @@ Feature: Agent Teams run-centric public API
   upstream context travels through the DAG prompt at spawn time.
 
   Background:
-    Given the @fradser/pi-agent-teams extension is loaded
+    Given the pi-agent-teams-fradser extension is loaded
 
   Rule: Agents are declarative Markdown files
 

--- a/packages/agent-teams/package.json
+++ b/packages/agent-teams/package.json
@@ -36,5 +36,8 @@
     "extensions": [
       "./src/index.ts"
     ]
+  },
+  "dependencies": {
+    "@fradser/pi-kit": "workspace:*"
   }
 }

--- a/packages/agent-teams/src/index.ts
+++ b/packages/agent-teams/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-agent-teams — Pi extension for run-centric agent teams.
+ * pi-agent-teams-fradser — Pi extension for run-centric agent teams.
  *
  * The entry point is composition only: worker capability registration,
  * session lifecycle, and delegation to tools.ts. Scheduling lives in

--- a/packages/agent-teams/src/spawner.ts
+++ b/packages/agent-teams/src/spawner.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractTextContent } from "@fradser/pi-kit";
 import type { WorkerUsage } from "./types";
 
 /**
@@ -307,10 +308,7 @@ function applyWorkerJsonLine(state: WorkerStreamState, line: string): boolean {
     if (event.type !== "message_end" || event.message?.role !== "assistant") return false;
     state.turns++;
     if (event.message.stopReason === "stop") state.finalResponse = true;
-    const parts = (event.message.content ?? [])
-      .filter((part) => part.type === "text" && typeof part.text === "string")
-      .map((part) => part.text as string)
-      .join("");
+    const parts = extractTextContent(event.message.content, "");
     if (parts.trim()) state.text = parts;
     const u = event.message.usage;
     if (u) {

--- a/packages/agent-teams/src/ui.ts
+++ b/packages/agent-teams/src/ui.ts
@@ -1,6 +1,7 @@
 /** Passive teammate widget and interactive full-screen console. */
 
 import { truncateToWidth, Key, matchesKey } from "@earendil-works/pi-tui";
+import { createPiThemeStyle, PI_SPINNER_FRAMES, PI_SPINNER_INTERVAL_MS } from "@fradser/pi-kit";
 import type { ExtensionUIContext, Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { truncateTail, DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
 import {
@@ -23,8 +24,6 @@ function cap(text: string | undefined, maxBytes = DEFAULT_MAX_BYTES): string {
 
 const TEAM_COLORS = ["accent", "success", "warning", "error", "toolTitle", "mdLink"] as const;
 const PANEL_IDLE_COLLAPSE_MS = 30_000;
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-const SPINNER_MS = 120;
 
 let panelRequestRender: (() => void) | undefined;
 let spinnerTimer: ReturnType<typeof setInterval> | undefined;
@@ -50,7 +49,7 @@ function buildPanelRows(): PanelRow[] {
 }
 
 function runningTeammateLabel(node: Node): string {
-  const frame = SPINNER_FRAMES[spinnerFrame];
+  const frame = PI_SPINNER_FRAMES[spinnerFrame];
   const tool = node.spawn?.activeTool;
   const thinking = (node.spawn?.liveThinking ?? "").split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
   const live = (node.spawn?.liveText ?? "").split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
@@ -71,9 +70,9 @@ function ensureSpinner(): void {
   const running = listNodes().some((node) => node.status === "running");
   if (running && !spinnerTimer) {
     spinnerTimer = setInterval(() => {
-      spinnerFrame = (spinnerFrame + 1) % SPINNER_FRAMES.length;
+      spinnerFrame = (spinnerFrame + 1) % PI_SPINNER_FRAMES.length;
       panelRequestRender?.();
-    }, SPINNER_MS);
+    }, PI_SPINNER_INTERVAL_MS);
     spinnerTimer.unref?.();
   } else if (!running && spinnerTimer) {
     clearInterval(spinnerTimer);
@@ -245,7 +244,7 @@ export function openTeamConsole(ctx: { ui: ExtensionUIContext }): Promise<void> 
     };
     const startLiveRefresh = () => {
       if (renderTimer) return;
-      renderTimer = setInterval(requestRender, SPINNER_MS);
+      renderTimer = setInterval(requestRender, PI_SPINNER_INTERVAL_MS);
       renderTimer.unref?.();
     };
     const stopLiveRefresh = () => {
@@ -256,14 +255,7 @@ export function openTeamConsole(ctx: { ui: ExtensionUIContext }): Promise<void> 
     startLiveRefresh();
 
     // btw-style callbacks (same accent/muted/dim/border/success/error language as pi-btw-fradser).
-    const style = {
-      accent: (s: string) => theme.fg("accent", s),
-      muted: (s: string) => theme.fg("muted", s),
-      dim: (s: string) => theme.fg("dim", s),
-      border: (s: string) => theme.fg("border", s),
-      success: (s: string) => theme.fg("success", s),
-      error: (s: string) => theme.fg("error", s),
-    };
+    const style = createPiThemeStyle(theme);
 
     const windowLines = (full: string[], width: number): { lines: string[]; range: string } => {
       const wrapped = wrapConsoleDetail(full, width);

--- a/packages/agent-teams/src/ui.ts
+++ b/packages/agent-teams/src/ui.ts
@@ -255,7 +255,7 @@ export function openTeamConsole(ctx: { ui: ExtensionUIContext }): Promise<void> 
     };
     startLiveRefresh();
 
-    // btw-style callbacks (same accent/muted/dim/border/success/error language as @fradser/pi-btw).
+    // btw-style callbacks (same accent/muted/dim/border/success/error language as pi-btw-fradser).
     const style = {
       accent: (s: string) => theme.fg("accent", s),
       muted: (s: string) => theme.fg("muted", s),
@@ -341,7 +341,7 @@ export function openTeamConsole(ctx: { ui: ExtensionUIContext }): Promise<void> 
           }
           const detail = wrapConsoleDetail(buildNodeDetail(detailKey), tui.terminal.columns);
           const viewport = maxConsoleBody(tui.terminal.rows);
-          // Mouse-wheel scrolling (SGR wheel events, same as @fradser/pi-btw).
+          // Mouse-wheel scrolling (SGR wheel events, same as pi-btw-fradser).
           const sgrWheel = /^\x1b\[<(\d+);(\d+);(\d+)[Mm]$/.exec(data);
           if (sgrWheel) {
             const button = Number.parseInt(sgrWheel[1], 10);

--- a/packages/agent-teams/tests/test_teammate_package.py
+++ b/packages/agent-teams/tests/test_teammate_package.py
@@ -61,7 +61,7 @@ def run_node(script: str, *args: str) -> dict[str, object]:
 
 def test_manifest_declares_native_extension_package() -> None:
     manifest = json.loads((PACKAGE / "package.json").read_text(encoding="utf-8"))
-    assert manifest["name"] == "@fradser/pi-agent-teams"
+    assert manifest["name"] == "pi-agent-teams-fradser"
     assert "pi-package" in manifest["keywords"]
     assert manifest["pi"] == {"extensions": ["./src/index.ts"]}
     assert "skills" not in manifest["files"]

--- a/packages/btw/README.md
+++ b/packages/btw/README.md
@@ -1,4 +1,4 @@
-# @fradser/pi-btw
+# pi-btw-fradser
 
 Side questions for Pi — `/btw <question>` answers a quick side question in a full-width
 overlay directly covering the main session input area, **without interrupting the current task and without ever
@@ -21,7 +21,7 @@ fixes that:
 ## Install
 
 ```bash
-pi install npm:@fradser/pi-btw
+pi install npm:pi-btw-fradser
 ```
 
 Restart pi, then use `/btw <question>` in interactive mode.

--- a/packages/btw/features/btw.feature
+++ b/packages/btw/features/btw.feature
@@ -3,7 +3,7 @@ Feature: Read-only side questions
   without adding a session or leaving temporary prompt material behind.
 
   Background:
-    Given the @fradser/pi-btw extension is installed
+    Given the pi-btw-fradser extension is installed
 
   Scenario: A child Pi run is configured read-only
     When a side question starts

--- a/packages/btw/package.json
+++ b/packages/btw/package.json
@@ -32,5 +32,8 @@
     "extensions": [
       "./src/index.ts"
     ]
+  },
+  "dependencies": {
+    "@fradser/pi-kit": "workspace:*"
   }
 }

--- a/packages/btw/src/context.ts
+++ b/packages/btw/src/context.ts
@@ -4,6 +4,8 @@
  * guarantee Claude Code's /btw gives, minus the tool-calling limitation).
  */
 
+import { extractTextContent } from "@fradser/pi-kit";
+
 export const DEFAULT_MAX_MESSAGES = 4;
 export const DEFAULT_MAX_CHARS = 4_000;
 
@@ -27,21 +29,6 @@ type BranchEntry = {
   };
 };
 
-function extractMessageText(msg: { role?: string; content?: unknown }): string {
-  const content = msg.content;
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .filter(
-        (part): part is { type?: string; text?: string } =>
-          typeof part === "object" && part !== null && "type" in part,
-      )
-      .map((part) => (part.type === "text" && typeof part.text === "string" ? part.text : ""))
-      .join("\n");
-  }
-  return "";
-}
-
 /**
  * Build a compact, most-recent-first conversation excerpt from the current
  * session branch. Only user and assistant text messages are included.
@@ -60,7 +47,7 @@ export function buildConversationContext(
     if (!entry || entry.type !== "message") continue;
     const msg = entry.message;
     if (!msg || (msg.role !== "user" && msg.role !== "assistant")) continue;
-    const text = extractMessageText(msg).trim();
+    const text = extractTextContent(msg.content).trim();
     if (!text) continue;
     parts.push(`[${msg.role}] ${text}`);
   }

--- a/packages/btw/src/index.ts
+++ b/packages/btw/src/index.ts
@@ -19,25 +19,12 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createPiThemeStyle } from "@fradser/pi-kit";
 import { buildConversationContext } from "./context";
-import { type BtwOverlayStyle, createBtwOverlay } from "./overlay";
+import { createBtwOverlay } from "./overlay";
 import { runBtw } from "./spawner";
 
 const DEFAULT_MODEL_ENV = "BTW_MODEL";
-
-function makeStyle(theme: {
-  fg(color: string, text: string): string;
-}): BtwOverlayStyle {
-  return {
-    accent: (s) => theme.fg("accent", s),
-    muted: (s) => theme.fg("muted", s),
-    dim: (s) => theme.fg("dim", s),
-    border: (s) => theme.fg("border", s),
-    success: (s) => theme.fg("success", s),
-    error: (s) => theme.fg("error", s),
-    fg: (color, s) => theme.fg(color, s),
-  };
-}
 
 export default function (pi: ExtensionAPI) {
   pi.registerCommand("btw", {
@@ -64,7 +51,7 @@ export default function (pi: ExtensionAPI) {
 
       await ctx.ui.custom<undefined>(
         (tui, theme, _kb, done) => {
-          const style = makeStyle(theme);
+          const style = createPiThemeStyle(theme);
 
           const overlay = createBtwOverlay(tui, style, {
             question,

--- a/packages/btw/src/index.ts
+++ b/packages/btw/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-btw — side questions for Pi.
+ * pi-btw-fradser — side questions for Pi.
  *
  * `/btw <question>` answers a quick side question in a full-width popup that
  * directly covers the main session input area, without interrupting the

--- a/packages/btw/src/overlay.ts
+++ b/packages/btw/src/overlay.ts
@@ -26,17 +26,11 @@ import {
   truncateToWidth,
   visibleWidth,
 } from "@earendil-works/pi-tui";
+import type { PiThemeStyle } from "@fradser/pi-kit";
 import type { BtwResult, BtwTurn, BtwUsage } from "./spawner";
 
-export interface BtwOverlayStyle {
-  accent: (s: string) => string;
-  muted: (s: string) => string;
-  dim: (s: string) => string;
-  border: (s: string) => string;
-  success: (s: string) => string;
-  error: (s: string) => string;
-  fg: (color: string, text: string) => string;
-}
+/** The shared pi-kit theme style language — btw's overlay style is that shape. */
+export type BtwOverlayStyle = PiThemeStyle;
 
 export interface BtwOverlayOptions {
   /** The initial side question as asked. */

--- a/packages/code-context/tests/test_code_context_package.py
+++ b/packages/code-context/tests/test_code_context_package.py
@@ -1,4 +1,4 @@
-"""Tests for the @fradser/pi-context pi package.
+"""Tests for the pi-context-fradser pi package.
 
 Guards the conversion from MCP sidecar servers (.mcp.json — pi has no built-in
 MCP support) to native pi extension tools that call the public REST APIs
@@ -23,7 +23,7 @@ class TestCodeContextManifest(unittest.TestCase):
         """package.json is a valid Pi package manifest with skills + extensions."""
         with open(os.path.join(CC_PKG_DIR, "package.json"), "r", encoding="utf-8") as f:
             data = json.load(f)
-        self.assertEqual(data["name"], "@fradser/pi-context")
+        self.assertEqual(data["name"], "pi-context-fradser")
         self.assertIn("pi-package", data.get("keywords", []))
         self.assertIn("skills", data["pi"])
         self.assertIn("extensions", data["pi"])

--- a/packages/context/AGENTS.md
+++ b/packages/context/AGENTS.md
@@ -1,0 +1,65 @@
+# Repository Guidelines
+
+## Package Scope
+
+`packages/context/` publishes `@fradser/pi-context`, a Pi skill and extension
+that exposes native DeepWiki, Context7, and Exa retrieval tools, plus clone and
+web-fetch fallbacks. Keep its README, `skills/context/SKILL.md`, extension
+behavior, and BDD scenarios aligned when the public workflow changes. Reuse
+`@fradser/pi-kit` for shared runtime helpers whenever that workspace package is
+available; follow the parent guide for its dependency and release rules.
+
+## Research before modifying this package
+
+Before editing `packages/context/`, classify the change and use the applicable native context tool first. These are Pi extension tools, not MCP servers:
+
+| Change type | First lookup | Fallback |
+| --- | --- | --- |
+| Pi API, package manifest, or TypeBox schema | `context_context7` | Local source inspection or official docs |
+| Public repository architecture or DeepWiki API behavior | `context_deepwiki` | Git clone |
+| Provider usage, integration patterns, or community examples | `context_exa` | Targeted web fetch |
+| A change spanning multiple categories | All applicable tools | Use each method's fallback |
+
+- `context_deepwiki`: use for changes involving a public repository's architecture, integration behavior, or DeepWiki API assumptions.
+- `context_context7`: use for changes involving Pi APIs, package manifests, TypeBox schemas, or external library/API contracts.
+- `context_exa`: use for changes involving real-world provider usage, current integration patterns, comparisons, or community examples. It requires `EXA_API_KEY`.
+
+Do not call unrelated tools for documentation-only or local-test-only changes. For every applicable call, record the result in the implementation notes or change summary. If a tool is unavailable or fails, state why and use the documented fallback in the relevant skill: local source inspection, git clone, or targeted web fetch.
+
+## Expected workflow
+
+1. Add or update a BDD scenario under `features/`.
+2. Run the applicable native context lookup(s) before implementation.
+3. Add a regression/unit test and confirm it fails before the fix when behavior changes.
+4. Implement the smallest change.
+5. Run `pnpm test` and package/type checks relevant to the change.
+6. Review the diff for stale MCP claims and verify package contents with `pnpm pack --dry-run` when packaging changes.
+
+## TUI Interaction & Styling Standards
+
+All interactive terminal UI components in Pi extensions (popups, overlays, status widgets, interactive dialogs) MUST strictly adhere to the `@packages/btw` TUI interaction pattern:
+
+### 1. Style Language & Theme Helpers
+Never hardcode ANSI escape codes or assume direct Theme object access. Always map colors through theme styling callbacks/helpers:
+- `accent`: theme-accent color (e.g. `theme.fg("accent", s)`) for primary highlights, spinners, titles (`Dreaming...`, `Answering...`), headings, and selected items.
+- `muted`: theme-muted color (`theme.fg("muted", s)`) for secondary metadata, parameters, or subtle hints.
+- `dim`: theme-dim color (`theme.fg("dim", s)`) for borders, separators, secondary info (` · tool_name`), and unselected/idle states.
+- `border`: theme-border color (`theme.fg("border", s)`) for dividing rules and panel frames.
+- `error` / `warning` / `success`: semantic theme colors (`theme.fg("error", s)`, etc.) for status indicators.
+
+### 2. Component Structure: Title + Detail Layout
+For status displays and widgets (such as `setWidget`), follow the compact single-line title + detail structure:
+- **Format**: `${icon} ${title}${detail}`
+- **Icon**: Braille spinner frame (`SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]`) styled with `accent`.
+- **Title**: Short, prominent title styled with `accent` (e.g. `Dreaming...` or `Answering...`). Do NOT pad with verbose explanatory sentences.
+- **Detail**: Optional, dynamic activity text prefixed with ` · ` and styled with `muted` or `dim` (e.g. ` · read package.json`).
+
+### 3. Modal Overlays (`ctx.ui.custom`)
+When rendering interactive overlays or modal consoles:
+- **Input Ownership**: Use `ctx.ui.custom` so the component exclusively owns keyboard input without polluting pi's global input dispatch (`onTerminalInput`).
+- **Standard Controls**: 
+  - `Esc` / `q`: Close or cancel.
+  - `↑` / `↓`: Line-by-line selection/scroll.
+  - `Enter`: Confirm selection or submit.
+- **Render Boundaries**: Constrain height (e.g. max ~40% terminal height) and calculate responsive text wrapping with `truncateToWidth` / `wrapTextWithAnsi` using the provided render `width`.
+- **Clean Lifecycle**: Always register a `dispose()` handler to clear timers (e.g. `clearInterval`), unref timeouts, and release TUI resources when closed.

--- a/packages/context/CHANGELOG.md
+++ b/packages/context/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @fradser/pi-context
+
+## 0.5.0
+
+### Minor Changes
+
+- f4fccb1: Republish all published package versions through GitHub CI to align with current release flow and regenerate their release metadata after version comparison.

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -1,0 +1,90 @@
+# Context Pi Package
+
+**Version:** 0.5.0
+
+Retrieve code context for any repo, library, or natural-language query via 5 methods: DeepWiki, Context7, Exa, git clone, and web search+fetch.
+
+The package does **not** ship a skill. Native tool guidance is injected into the system prompt, and the `/context` command loads the full workflow into the current turn.
+
+## Installation
+
+```bash
+pi install npm:@fradser/pi-context
+# or from this repository:
+pi install /path/to/pi-packages/packages/context
+```
+
+## Usage
+
+Run `/context` followed by a natural-language question, repository slug, library name, or several targets. For example:
+
+```text
+/context React 19 server actions error handling
+/context facebook/react
+/context facebook/react zustand --method=deepwiki,context7
+```
+
+`--method=` accepts `deepwiki,context7,exa,clone,web,all` (comma-separated). With no target, the command reads dependency manifests in the current directory (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`) and uses detected dependencies as targets.
+
+The full workflow (target classification, per-method process, fallbacks, selection guide) lives in `references/workflow.md` and is injected into the turn when `/context` runs. Lightweight tool-selection guidance is always present in the system prompt.
+
+## Runtime requirements
+
+| Method | Availability | Notes |
+|--------|--------------|-------|
+| DeepWiki | Always (native tool `context_deepwiki`) | No API key required |
+| Context7 | Always (native tool `context_context7`) | Optional `CONTEXT7_API_KEY` (Bearer) for per-key quota |
+| Exa | Native tool `context_exa` | Requires `EXA_API_KEY` env var |
+| Git clone | Always | Pi `bash` + `read` |
+| Web fetch | Always | `curl`/HTTP via `bash` |
+
+All three retrieval tools are registered by this package's extension (`extensions/context-tools.ts`) and call the public REST APIs directly — no MCP servers needed.
+
+## Methods (summary)
+
+1. **DeepWiki** — AI-generated repo docs via `context_deepwiki` (`mode: structure | contents | ask`).
+2. **Context7** — up-to-date library docs via `context_context7` (`query` + optional `topic`).
+3. **Exa** — web/code search via `context_exa` (`query` + optional `numResults`, requires `EXA_API_KEY`).
+4. **Git clone** — `git clone --depth=1` to `/tmp`, `read` key files, clean up.
+5. **Web search+fetch** — `bash` + `curl` against official docs, GitHub issues, changelogs.
+
+If a native tool is unavailable or errors, fall back to clone/web. The `/context` workflow reference contains the full selection matrix and per-method process.
+
+## Optional manual brief
+
+`agents/context-researcher.md` is an optional manual prompt brief for an isolated research pass. Pi does not load it as an invocable agent; use the `/context` command for the executable workflow.
+
+## Structure
+
+```
+context/
+├── extensions/
+│   ├── context-tools.ts         # Native pi tools: context_deepwiki / context_context7 / context_exa
+│   └── context-command.ts       # /context command + system-prompt guidance
+├── references/
+│   └── workflow.md              # Full workflow injected by /context
+├── agents/
+│   └── context-researcher.md    # Isolated research brief (manual)
+└── README.md
+```
+
+## Prerequisites
+
+- Pi with extensions + custom tools
+- Network access for external lookups
+- `EXA_API_KEY` for the Exa method (optional for the other four)
+
+## Best Practices
+
+- **Local first**: check local context (package.json, imports) before external lookups.
+- **Combine methods**: DeepWiki / clone for architecture, Context7 for API surface, Exa / web for community patterns.
+- **Verify sources**: cross-reference fetched content against actual code.
+- **Clean up**: remove `/tmp` clones when finished.
+
+## License
+
+MIT
+
+## Author
+
+Frad LEE (fradser@gmail.com)

--- a/packages/context/agents/context-researcher.md
+++ b/packages/context/agents/context-researcher.md
@@ -1,0 +1,36 @@
+---
+name: context-researcher
+description: Research a library, repository, or code pattern without polluting the main conversation. Uses the native context_deepwiki/context_context7/context_exa tools when applicable, otherwise git clone + HTTP fetch via Pi bash/read. Accepts natural-language queries, repo slugs, library names, or any combination.
+---
+
+# Context researcher (optional agent brief)
+
+Pi does not load Claude Code agent files automatically. Treat this file as a **prompt brief** when you want an isolated research pass. Prefer the `/context` command for the executable workflow.
+
+## Runtime requirements
+
+| Method | Requirement |
+|--------|-------------|
+| DeepWiki | Native `context_deepwiki` tool |
+| Context7 | Native `context_context7` tool |
+| Exa | Native `context_exa` tool (+ optional `EXA_API_KEY`) |
+| Git clone | `git` + Pi `bash` / `read` (always) |
+| Web | `curl` or host HTTP via Pi `bash` (always) |
+
+If a native context tool is unavailable or fails, skip that method, use clone + web, and report which methods ran and why the fallback was needed.
+
+## Process
+
+1. **Parse the request** — targets and optional `--method=` list (see `/context`).
+2. **Classify** each target (repo / library / natural-language).
+3. **Select methods** per the `/context` workflow's selection guide.
+4. **Execute with Pi tools** — use the applicable native context tools (`context_deepwiki`, `context_context7`, `context_exa`) plus `bash` and `read`. Summarize intermediates; do not dump raw payloads.
+5. **Return** a concise architecture/API/examples summary only.
+
+## Output format
+
+- Target classification
+- Methods used (and skipped, with reason)
+- Key findings (bullets)
+- Copyable snippets only when necessary
+- Open questions / confidence notes

--- a/packages/context/extensions/context-tools.ts
+++ b/packages/context/extensions/context-tools.ts
@@ -1,0 +1,277 @@
+/**
+ * Native pi tools for DeepWiki / Context7 / Exa retrieval.
+ *
+ * Replaces the package's `.mcp.json` (MCP servers). pi has no built-in MCP
+ * support (docs/usage.md), so these tools call the public REST APIs directly:
+ *   - context_deepwiki  → https://mcp.deepwiki.com/mcp (DeepWiki's public JSON-RPC/SSE API)
+ *   - context_context7  → https://context7.com/api/v1/{search,docs}
+ *   - context_exa       → https://api.exa.ai/search  (needs EXA_API_KEY)
+ *
+ * Pure HTTP tools — available in interactive and non-interactive runs alike.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { truncateHead, DEFAULT_MAX_LINES } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+const MAX_CHARS = 60_000;
+const TIMEOUT_MS = 30_000;
+const DEEPWIKI_MCP = "https://mcp.deepwiki.com/mcp";
+
+interface ToolTextResult {
+	content: [{ type: "text"; text: string }];
+	details: Record<string, unknown>;
+}
+
+function textResult(text: string, details: Record<string, unknown> = {}): ToolTextResult {
+	return { content: [{ type: "text", text }], details };
+}
+
+function truncate(text: string): string {
+	if (text.length <= MAX_CHARS) return text;
+	const result = truncateHead(text, { maxLines: DEFAULT_MAX_LINES, maxBytes: MAX_CHARS });
+	return `${result.content}\n\n…[truncated ${text.length - MAX_CHARS} chars]`;
+}
+
+function requestSignal(signal: AbortSignal | undefined): AbortSignal {
+	const timeout = AbortSignal.timeout(TIMEOUT_MS);
+	return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+async function httpJson(
+	url: string,
+	init: RequestInit = {},
+	signal: AbortSignal | undefined,
+): Promise<{ ok: boolean; status: number; body: string }> {
+	const res = await fetch(url, { ...init, signal: requestSignal(signal) });
+	const body = await res.text();
+	return { ok: res.ok, status: res.status, body };
+}
+
+/**
+ * DeepWiki's public API is a JSON-RPC-over-HTTP/SSE endpoint (mcp.deepwiki.com).
+ * Call a tool directly — no MCP client or sidecar process needed.
+ */
+async function deepwikiCall(
+	tool: string,
+	args: Record<string, unknown>,
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	const res = await fetch(DEEPWIKI_MCP, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "application/json, text/event-stream",
+		},
+		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: tool, arguments: args } }),
+		signal: requestSignal(signal),
+	});
+	const body = await res.text();
+	if (!res.ok) throw new Error(`DeepWiki HTTP ${res.status}: ${body.slice(0, 200)}`);
+
+	// SSE frames: `event: message` + one or more `data:` lines, blank-line terminated.
+	// Join multiline payloads, keep the last frame with data.
+	let payload: string | null = null;
+	let currentData: string[] = [];
+	for (const raw of body.split("\n")) {
+		const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+		if (line === "") {
+			if (currentData.length > 0) payload = currentData.join("\n");
+			currentData = [];
+			continue;
+		}
+		if (line.startsWith(":")) continue; // SSE comment
+		if (line.startsWith("data:")) {
+			currentData.push(line.slice(5).replace(/^ /, ""));
+		}
+	}
+	if (currentData.length > 0) payload = currentData.join("\n");
+	if (payload === null) throw new Error("DeepWiki: no data frame in response");
+
+	const data = JSON.parse(payload);
+	if (data.error) throw new Error(`DeepWiki: ${data.error.message ?? JSON.stringify(data.error)}`);
+	const content = data.result?.content;
+	if (Array.isArray(content)) {
+		return content.map((c) => (typeof c?.text === "string" ? c.text : JSON.stringify(c))).join("\n");
+	}
+	return JSON.stringify(data.result ?? data);
+}
+
+const DeepWikiParams = Type.Object({
+	owner: Type.String({ description: "GitHub owner, e.g. 'facebook'" }),
+	repo: Type.String({ description: "GitHub repository name, e.g. 'react'" }),
+	mode: StringEnum(["structure", "contents", "ask"], {
+		description: "structure = table of contents; contents = full wiki text; ask = targeted Q&A",
+	}),
+	question: Type.Optional(
+		Type.String({ description: "Required when mode is 'ask'; the question about the repository" }),
+	),
+});
+const Context7Params = Type.Object({
+	query: Type.String({ description: "Library name to find docs for, e.g. 'fastapi' or 'react'" }),
+	topic: Type.Optional(
+		Type.String({ description: "Optional topic focus, e.g. 'auth' or 'ssr' (best results with a topic)" }),
+	),
+});
+
+const ExaParams = Type.Object({
+	query: Type.String({ description: "Precise natural-language or code query" }),
+	numResults: Type.Optional(
+		Type.Number({ description: "Number of results (default 5)", default: 5 }),
+	),
+});
+
+export function registerContextTools(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "context_deepwiki",
+		label: "DeepWiki repo docs",
+		description:
+			"Fetch AI-generated documentation for a public GitHub repository from DeepWiki. " +
+			"mode=structure returns the table of contents; mode=contents returns the full wiki text; " +
+			"mode=ask answers a specific question with sources. No API key required.",
+		promptSnippet: "Look up AI-generated documentation for a public GitHub repo from DeepWiki",
+		promptGuidelines: [
+			"Use context_deepwiki to fetch structured repo documentation via DeepWiki instead of cloning when you only need a high-level understanding.",
+		],
+		parameters: DeepWikiParams,
+		executionMode: "sequential",
+
+		async execute(_toolCallId, params, signal) {
+			const repo = `${params.owner}/${params.repo}`;
+			if (params.mode === "ask") {
+				if (!params.question) {
+					return textResult("context_deepwiki: mode 'ask' requires a question");
+				}
+				const answer = await deepwikiCall("ask_question", { repoName: repo, question: params.question }, signal);
+				return textResult(truncate(answer));
+			}
+			const tool = params.mode === "structure" ? "read_wiki_structure" : "read_wiki_contents";
+			const out = await deepwikiCall(tool, { repoName: repo }, signal);
+			return textResult(truncate(out));
+		},
+	});
+
+	pi.registerTool({
+		name: "context_context7",
+		label: "Context7 library docs",
+		description:
+			"Fetch up-to-date, version-aware documentation snippets for a library from Context7. " +
+			"Searches the library, then retrieves markdown docs (optionally focused on a topic). " +
+			"Anonymous usage is rate-limited; set CONTEXT7_API_KEY (Authorization: Bearer) for per-key quota.",
+		promptSnippet: "Look up version-aware library documentation from Context7",
+		promptGuidelines: [
+			"Use context_context7 to look up library docs instead of guessing APIs from memory. Anonymous usage is rate-limited; set CONTEXT7_API_KEY for higher quota.",
+		],
+		parameters: Context7Params,
+		executionMode: "sequential",
+
+		async execute(_toolCallId, params, signal) {
+			const headers: Record<string, string> = {};
+			if (process.env.CONTEXT7_API_KEY) {
+				headers.Authorization = `Bearer ${process.env.CONTEXT7_API_KEY}`;
+			}
+
+			const { ok, status, body } = await httpJson(
+				`https://context7.com/api/v1/search?query=${encodeURIComponent(params.query)}`,
+				{ headers },
+				signal,
+			);
+			if (!ok) {
+				if (status === 401 || status === 403) {
+					return textResult(
+						`Context7 search needs an API key (HTTP ${status}). Set CONTEXT7_API_KEY ` +
+							`(Authorization: Bearer) or fall back to web/clone methods.`,
+					);
+				}
+				throw new Error(`Context7 search failed (HTTP ${status}): ${body.slice(0, 400)}`);
+			}
+
+			let data: { results?: Array<{ id?: unknown }> };
+			try {
+				data = JSON.parse(body);
+			} catch {
+				throw new Error(`Context7 search: unexpected response: ${body.slice(0, 400)}`);
+			}
+			const results = Array.isArray(data.results) ? data.results : [];
+			if (results.length === 0) {
+				return textResult(`Context7: no library found for "${params.query}"`);
+			}
+			const libraryId = typeof results[0]?.id === "string" ? results[0].id : "";
+			if (!libraryId) {
+				return textResult(`Context7: search returned no usable library id for "${params.query}"`);
+			}
+
+			// v1 doc ids look like "/owner/repo" — strip the leading slash for the path.
+			const path = libraryId.startsWith("/") ? libraryId.slice(1) : libraryId;
+			const topic = params.topic ? `&topic=${encodeURIComponent(params.topic)}` : "";
+			const docUrl = `https://context7.com/api/v1/${path}?type=txt${topic}`;
+			const doc = await httpJson(docUrl, { headers }, signal);
+			if (!doc.ok) {
+				throw new Error(`Context7 docs failed (HTTP ${doc.status}): ${doc.body.slice(0, 400)}`);
+			}
+			return textResult(
+				`Context7 docs for "${params.query}" (${libraryId})${params.topic ? `, topic ${params.topic}` : ""}:\n\n${truncate(doc.body)}`,
+			);
+		},
+	});
+
+	pi.registerTool({
+		name: "context_exa",
+		label: "Exa web/code search",
+		description:
+			"Search the web for real-world code patterns, comparisons, and up-to-date information via Exa. " +
+			"Requires the EXA_API_KEY environment variable. Returns titles, URLs, and text snippets.",
+		promptSnippet: "Search the web for real-world code patterns, comparisons, and up-to-date information via Exa",
+		promptGuidelines: [
+			"Use context_exa to search the web when you need current information, code patterns, or comparisons. Requires EXA_API_KEY to be set.",
+		],
+		parameters: ExaParams,
+		executionMode: "sequential",
+
+		async execute(_toolCallId, params, signal) {
+			const apiKey = process.env.EXA_API_KEY;
+			if (!apiKey) {
+				return textResult(
+					"context_exa: EXA_API_KEY is not set. Set EXA_API_KEY to enable Exa search, " +
+						"or fall back to web search via curl / GitHub search.",
+				);
+			}
+
+			const numResults = Math.max(1, Math.min(10, Math.floor(params.numResults ?? 5)));
+			const { ok, status, body } = await httpJson(
+				"https://api.exa.ai/search",
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"x-api-key": apiKey,
+					},
+					body: JSON.stringify({ query: params.query, numResults, contents: { text: true } }),
+				},
+				signal,
+			);
+			if (!ok) throw new Error(`Exa search failed (HTTP ${status}): ${body.slice(0, 400)}`);
+
+			let data: { results?: Array<{ title?: string; url?: string; text?: string }> };
+			try {
+				data = JSON.parse(body);
+			} catch {
+				throw new Error(`Exa search: unexpected response: ${body.slice(0, 400)}`);
+			}
+			const results = Array.isArray(data.results) ? data.results : [];
+			if (results.length === 0) {
+				return textResult(`Exa: no results for "${params.query}"`);
+			}
+			const lines = results.map((r, i) => {
+				const title = r.title || r.url || "(untitled)";
+				const url = r.url || "";
+				const text = typeof r.text === "string" ? r.text.slice(0, 1200) : "";
+				return `${i + 1}. ${title}\n   ${url}\n${text ? `   ${text}` : ""}`;
+			});
+			return textResult(truncate(lines.join("\n\n")));
+		},
+	});
+}
+
+export default registerContextTools;

--- a/packages/context/features/modification-research-gate.feature
+++ b/packages/context/features/modification-research-gate.feature
@@ -1,0 +1,22 @@
+Feature: Research before modifying the code-context package
+  To keep changes aligned with current Pi and retrieval integrations
+  As a maintainer of @fradser/code-context
+  I want package modifications to consult the applicable native context tools first
+
+  Scenario: A Pi integration change consults current Pi documentation
+    Given a change targets the code-context package
+    And the change concerns Pi extension or package APIs
+    When the maintainer starts implementation
+    Then the maintainer uses context_context7 or context_deepwiki before editing
+
+  Scenario: A retrieval-provider change consults the affected provider context
+    Given a change targets a retrieval provider integration
+    When the maintainer starts implementation
+    Then the maintainer uses the native context tool for the affected provider when applicable
+    And the maintainer records unavailable tools and uses a documented fallback
+
+  Scenario: Unrelated changes do not require irrelevant lookups
+    Given a change targets documentation or local tests only
+    And it does not change Pi APIs or retrieval-provider behavior
+    When the maintainer starts implementation
+    Then the maintainer does not call unrelated context tools

--- a/packages/context/features/native-tool-runtime.feature
+++ b/packages/context/features/native-tool-runtime.feature
@@ -1,0 +1,34 @@
+Feature: Native context tool behavior
+  To expose only usable Pi-native interfaces and truthful retrieval failures
+  As a user of @fradser/pi-context
+  I want the documented command surface and tool results to match the Pi runtime
+
+  Scenario: The README advertises the /context command rather than skills
+    Given the context package is installed in Pi
+    When I read its README
+    Then it documents /context as the entry point
+    And it may describe context-researcher only as an optional manual prompt brief
+    But it does not advertise any skill path or invocable agent
+
+  Scenario: An in-flight provider lookup is cancelled by Pi
+    Given a context lookup is waiting for an HTTP response
+    When Pi aborts the tool execution signal
+    Then the HTTP request is aborted
+    And the tool execution fails rather than returning cancellation as a successful text result
+
+  Scenario: A retrieval provider is unreachable
+    Given a context HTTP request fails before receiving a response
+    When the associated native tool runs
+    Then the tool execution fails so Pi records an error result
+
+  Scenario: A required Exa credential is absent
+    Given EXA_API_KEY is not configured
+    When context_exa runs
+    Then it returns a nonfatal message explaining how to configure the credential
+    And it does not make an HTTP request
+
+  Scenario: A provider request exceeds its timeout
+    Given a context HTTP request has no Pi execution signal
+    When the configured request timeout elapses
+    Then the request signal is aborted
+

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@fradser/pi-context",
+  "version": "0.5.0",
+  "description": "Retrieve code context for any repo, library, or natural-language query via DeepWiki, Context7, Exa, git clone, and web search+fetch. Native pi tools (context_deepwiki/context_context7/context_exa) call the public REST APIs directly — no MCP servers.",
+  "keywords": [
+    "pi-package",
+    "code-context",
+    "deepwiki",
+    "context7",
+    "exa"
+  ],
+  "author": "Frad LEE <fradser@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FradSer/pi-packages.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "extensions",
+    "references",
+    "agents",
+    "README.md"
+  ],
+  "pi": {
+    "extensions": [
+      "./extensions/context-tools.ts",
+      "./extensions/context-command.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-ai": "*",
+    "typebox": "*"
+  }
+}

--- a/packages/context/tests/context_tools_harness.mts
+++ b/packages/context/tests/context_tools_harness.mts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+
+const extensionPath = process.argv[2];
+assert.ok(extensionPath, "expected compiled extension path");
+const { default: extension } = await import(extensionPath);
+
+type RegisteredTool = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal?: AbortSignal,
+  ) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+};
+
+const tools = new Map<string, RegisteredTool>();
+extension({
+  registerTool(tool: RegisteredTool) {
+    tools.set(tool.name, tool);
+  },
+} as never);
+
+function tool(name: string): RegisteredTool {
+  const registered = tools.get(name);
+  assert.ok(registered, `${name} must be registered`);
+  return registered;
+}
+
+async function main(): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const originalExaKey = process.env.EXA_API_KEY;
+
+  try {
+    let requestWasAborted = false;
+    globalThis.fetch = ((_url, init) => {
+      const signal = init?.signal;
+      assert.ok(signal, "HTTP request needs a signal");
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            requestWasAborted = true;
+            reject(signal.reason);
+          },
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    const cancelled = tool("context_deepwiki").execute(
+      "cancelled",
+      { owner: "facebook", repo: "react", mode: "structure" },
+      controller.signal,
+    );
+    controller.abort(new Error("Pi cancelled the lookup"));
+    await assert.rejects(cancelled, /Pi cancelled the lookup/);
+    assert.equal(requestWasAborted, true);
+
+    globalThis.fetch = (async () => new Response("provider unavailable", { status: 503 })) as typeof fetch;
+    await assert.rejects(
+      tool("context_context7").execute("context7-503", { query: "react" }),
+      /Context7 search failed \(HTTP 503\)/,
+    );
+
+    process.env.EXA_API_KEY = "test-key";
+    await assert.rejects(
+      tool("context_exa").execute("exa-503", { query: "react" }),
+      /Exa search failed \(HTTP 503\)/,
+    );
+
+    delete process.env.EXA_API_KEY;
+    let requestedWithoutKey = false;
+    globalThis.fetch = (async () => {
+      requestedWithoutKey = true;
+      throw new Error("no request should be made");
+    }) as typeof fetch;
+    const missingKey = await tool("context_exa").execute("no-key", { query: "react" });
+    assert.match(missingKey.content[0]?.text ?? "", /EXA_API_KEY is not set/);
+    assert.equal(requestedWithoutKey, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalExaKey === undefined) {
+      delete process.env.EXA_API_KEY;
+    } else {
+      process.env.EXA_API_KEY = originalExaKey;
+    }
+  }
+}
+
+void main();

--- a/packages/context/tests/test_context_package.py
+++ b/packages/context/tests/test_context_package.py
@@ -1,0 +1,230 @@
+"""Tests for the @fradser/pi-context pi package.
+
+Guards the conversion from MCP sidecar servers (.mcp.json — pi has no built-in
+MCP support) to native pi extension tools that call the public REST APIs
+directly, and the prompt-injected /context command that replaced the skill.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+import unittest
+
+CC_PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def read(rel: str) -> str:
+    with open(os.path.join(CC_PKG_DIR, rel), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestContextManifest(unittest.TestCase):
+    def test_package_json_validity(self):
+        """package.json is a valid Pi package manifest with extensions and references."""
+        data = json.loads(read("package.json"))
+        self.assertEqual(data["name"], "@fradser/pi-context")
+        self.assertIn("pi-package", data.get("keywords", []))
+        self.assertNotIn("skills", data.get("pi", {}), "skills section must be removed")
+        self.assertIn("extensions", data["pi"])
+        self.assertIn("extensions", data.get("files", []))
+        self.assertIn("references", data.get("files", []))
+        self.assertIn("@earendil-works/pi-coding-agent", data.get("peerDependencies", {}))
+        self.assertIn("@earendil-works/pi-ai", data.get("peerDependencies", {}))
+        self.assertIn("typebox", data.get("peerDependencies", {}))
+        self.assertNotIn(".mcp.json", data.get("files", []))
+        self.assertNotIn("skills", data.get("files", []))
+
+    def test_no_skill_directory(self):
+        """The package ships no skills/ directory — guidance is prompt-injected."""
+        self.assertFalse(
+            os.path.exists(os.path.join(CC_PKG_DIR, "skills")),
+            "skills/ must be removed — use prompt injection + /context command",
+        )
+
+    def test_no_mcp_server_config(self):
+        """The MCP sidecar config must be gone (pi has no built-in MCP)."""
+        self.assertFalse(
+            os.path.exists(os.path.join(CC_PKG_DIR, ".mcp.json")),
+            ".mcp.json must be removed — pi has no built-in MCP support",
+        )
+
+
+class TestModificationResearchGuidance(unittest.TestCase):
+    def test_agents_md_names_native_tools(self):
+        """Package maintainer guidance names each native context tool."""
+        content = read("AGENTS.md")
+        self.assertIn("context_deepwiki", content)
+        self.assertIn("context_context7", content)
+        self.assertIn("context_exa", content)
+        self.assertIn("Before editing", content)
+
+
+class TestContextToolsExtension(unittest.TestCase):
+    def test_extension_registers_native_tools(self):
+        """extensions/context-tools.ts registers the three REST tools."""
+        content = read(os.path.join("extensions", "context-tools.ts"))
+        self.assertIn('name: "context_deepwiki"', content)
+        self.assertIn('name: "context_context7"', content)
+        self.assertIn('name: "context_exa"', content)
+        self.assertIn("mcp.deepwiki.com", content)
+        self.assertIn("context7.com", content)
+        self.assertIn("api.exa.ai", content)
+        self.assertIn("EXA_API_KEY", content)
+        self.assertIn("StringEnum", content)
+        self.assertNotIn("Type.Union", content)
+
+    def test_workflow_reference_has_no_mcp_references(self):
+        """The workflow reference routes to the native tools, never MCP servers."""
+        content = read(os.path.join("references", "workflow.md"))
+        self.assertNotIn("MCP", content)
+        self.assertNotIn("mcp", content)
+
+    def test_workflow_reference_names_native_tools(self):
+        for tool in ("context_deepwiki", "context_context7", "context_exa"):
+            self.assertIn(tool, read(os.path.join("references", "workflow.md")))
+
+
+class TestContextCommandExtension(unittest.TestCase):
+    def test_registers_context_command(self):
+        content = read(os.path.join("extensions", "context-command.ts"))
+        self.assertIn('registerCommand("context"', content)
+        self.assertIn("sendUserMessage", content)
+        self.assertIn("references", content)
+        self.assertIn("workflow.md", content)
+
+    def test_injects_guidance_into_system_prompt(self):
+        content = read(os.path.join("extensions", "context-command.ts"))
+        self.assertIn('pi.on("before_agent_start"', content)
+        self.assertIn("systemPrompt", content)
+        self.assertIn("context_deepwiki", content)
+        self.assertIn("context_context7", content)
+        self.assertIn("context_exa", content)
+        self.assertIn("/context", content)
+
+
+class TestReadmeContract(unittest.TestCase):
+    def test_readme_has_no_mcp_claims(self):
+        content = read("README.md")
+        self.assertNotIn(".mcp.json", content)
+        self.assertNotIn("MCP Servers Required", content)
+        self.assertNotIn("Claude Code CLI", content)
+        for tool in (
+            "read_wiki_structure",
+            "read_wiki_contents",
+            "resolve-library-id",
+            "query-docs",
+            "get_code_context_exa",
+        ):
+            self.assertNotIn(tool, content, f"stale MCP tool name {tool} in README")
+
+    def test_readme_advertises_context_command_only(self):
+        """README documents /context, not any skill path."""
+        content = read("README.md")
+        self.assertIn("/context", content)
+        self.assertNotIn("/skill:context", content)
+        self.assertNotIn("/skill:get-context", content)
+        self.assertNotIn("/skill:code-context", content)
+        self.assertNotIn("skills/", content)
+        self.assertIn("optional manual prompt brief", content)
+
+    def test_readme_version_matches_manifest(self):
+        readme = read("README.md")
+        manifest = json.loads(read("package.json"))
+        self.assertIn(f"**Version:** {manifest['version']}", readme)
+
+
+class TestFeatureContract(unittest.TestCase):
+    def test_feature_does_not_reference_skills(self):
+        feature = read(os.path.join("features", "native-tool-runtime.feature"))
+        self.assertNotIn("/skill:", feature)
+        for phrase in (
+            "/context",
+            "optional manual prompt brief",
+            "Pi aborts the tool execution signal",
+            "fails so Pi records an error result",
+            "EXA_API_KEY is not configured",
+            "configured request timeout elapses",
+        ):
+            self.assertIn(phrase, feature)
+
+
+class TestHttpBehavior(unittest.TestCase):
+    def test_http_tools_forward_pi_abort_signal_and_timeout(self):
+        content = read(os.path.join("extensions", "context-tools.ts"))
+        self.assertIn("function requestSignal(signal: AbortSignal | undefined)", content)
+        self.assertIn("AbortSignal.any", content)
+        self.assertIn("AbortSignal.timeout(TIMEOUT_MS)", content)
+        self.assertRegex(content, r"httpJson\([\s\S]*signal: AbortSignal \| undefined")
+        self.assertRegex(content, r"deepwikiCall\([\s\S]*signal: AbortSignal \| undefined")
+
+    def test_operational_http_failures_are_thrown_but_missing_key_is_informational(self):
+        content = read(os.path.join("extensions", "context-tools.ts"))
+        self.assertIn("throw new Error(`Context7 search failed", content)
+        self.assertIn("throw new Error(`Context7 docs failed", content)
+        self.assertIn("throw new Error(`Exa search failed", content)
+        self.assertNotIn("catch (err)", content)
+        self.assertIn("EXA_API_KEY is not set", content)
+
+    def test_native_tools_abort_and_signal_operational_failures_at_runtime(self):
+        workspace_dir = os.path.dirname(os.path.dirname(CC_PKG_DIR))
+        candidates = glob.glob(
+            os.path.join(
+                workspace_dir,
+                "node_modules",
+                ".pnpm",
+                "esbuild@*",
+                "node_modules",
+                "esbuild",
+                "bin",
+                "esbuild",
+            )
+        )
+        self.assertTrue(candidates, "test requires the workspace esbuild binary")
+        esbuild = candidates[0]
+        build_dir = os.path.join(CC_PKG_DIR, ".test-build")
+        os.makedirs(build_dir, exist_ok=True)
+        extension = os.path.join(build_dir, "context-tools.mjs")
+        try:
+            build = subprocess.run(
+                [
+                    esbuild,
+                    "packages/context/extensions/context-tools.ts",
+                    "--bundle",
+                    "--platform=node",
+                    "--format=esm",
+                    "--external:@earendil-works/pi-coding-agent",
+                    "--external:@earendil-works/pi-ai",
+                    "--external:typebox",
+                    f"--outfile={extension}",
+                ],
+                cwd=workspace_dir,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            self.assertEqual(build.returncode, 0, f"{build.stderr}\n{build.stdout}")
+            result = subprocess.run(
+                [
+                    "node",
+                    "--import",
+                    "tsx",
+                    "packages/context/tests/context_tools_harness.mts",
+                    f"file://{extension}",
+                ],
+                cwd=workspace_dir,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        finally:
+            shutil.rmtree(build_dir)
+        self.assertEqual(result.returncode, 0, f"{result.stderr}\n{result.stdout}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -17,7 +17,7 @@ Two locations must stay **identical** (idempotent):
 
 ```bash
 # published
-pi install npm:@fradser/pi-memory
+pi install npm:pi-memory-fradser
 # or from this repo: pi install /path/to/pi-packages/packages/memory
 ```
 

--- a/packages/memory/extensions/config.ts
+++ b/packages/memory/extensions/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { nonEmpty, parseModelRef } from "@fradser/pi-kit";
 
 export interface MemoryConfig {
   provider?: string;
@@ -8,26 +9,6 @@ export interface MemoryConfig {
 }
 
 const CONFIG_PATH = join(getAgentDir(), "memory.json");
-
-function nonEmpty(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-export function parseModelRef(value: string | undefined): { provider: string; model: string } | undefined {
-  const ref = nonEmpty(value);
-  if (!ref) return undefined;
-  const separator = ref.indexOf("/");
-  if (separator <= 0 || separator === ref.length - 1) return undefined;
-  return {
-    provider: ref.slice(0, separator),
-    model: ref.slice(separator + 1),
-  };
-}
-
-export function modelRef(config: MemoryConfig): string | undefined {
-  if (config.provider && config.model) return `${config.provider}/${config.model}`;
-  return config.model;
-}
 
 export function readMemoryConfig(): MemoryConfig {
   let file: Partial<MemoryConfig> = {};

--- a/packages/memory/extensions/inject-memory.ts
+++ b/packages/memory/extensions/inject-memory.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-memory — native pi /memory command.
+ * pi-memory-fradser — native pi /memory command.
  *
  * Replaces the /skill:consolidate skill surface with a pi-native command menu:
  *

--- a/packages/memory/extensions/inject-memory.ts
+++ b/packages/memory/extensions/inject-memory.ts
@@ -26,17 +26,22 @@ import os from "os";
 import { spawn } from "node:child_process";
 import * as nodeFs from "node:fs";
 import { fileURLToPath } from "node:url";
-import type { Api, Model } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+  enterModelFromInput,
+  modelRef,
+  parseModelRef,
+  PI_SPINNER_FRAMES,
+  selectModelFromMenu,
+  sortModels,
+} from "@fradser/pi-kit";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import {
   memoryConfigPath,
-  modelRef,
-  parseModelRef,
   readMemoryConfig,
   writeMemoryConfig,
   type MemoryConfig,
-} from "../config";
+} from "./config";
 
 export function getEscapedCwd(cwd: string): string {
   return cwd.replace(/\//g, "-");
@@ -333,7 +338,6 @@ export function missingConsolidationEvidence(evidence: ConsolidationEvidence): s
 }
 
 const DREAM_TIMEOUT_MS = 20 * 60 * 1000;
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 let dreamingTimer: NodeJS.Timeout | undefined;
 let dreamingActivity = "";
@@ -356,7 +360,7 @@ function setDreamingWidget(ctx: ExtensionContext): void {
 
     return {
       render: (_width: number) => {
-        const frame = SPINNER_FRAMES[frameIndex % SPINNER_FRAMES.length];
+        const frame = PI_SPINNER_FRAMES[frameIndex % PI_SPINNER_FRAMES.length];
         const icon = theme?.fg ? theme.fg("accent", frame) : frame;
         const text = theme?.fg ? theme.fg("accent", "Dreaming...") : "Dreaming...";
         const detail = dreamingActivity
@@ -378,15 +382,11 @@ function setDreamingWidget(ctx: ExtensionContext): void {
   });
 }
 
-function modelLabel(model: Model<Api>): string {
-  return `${model.provider}/${model.id}`;
-}
-
-function availableMemoryModels(ctx: ExtensionContext): Model<Api>[] {
+function availableMemoryModels(ctx: ExtensionContext) {
   const models = ctx.scopedModels.length > 0
     ? ctx.scopedModels.map((scoped) => scoped.model)
     : ctx.modelRegistry.getAvailable();
-  return models.sort((left, right) => modelLabel(left).localeCompare(modelLabel(right)));
+  return sortModels(models);
 }
 
 function configuredMemoryModel(): string {
@@ -399,21 +399,22 @@ function saveMemoryConfig(next: MemoryConfig): void {
 }
 
 async function chooseMemoryModel(ctx: ExtensionContext): Promise<void> {
-  const models = availableMemoryModels(ctx);
-  if (models.length === 0) {
-    ctx.ui.notify("No models are available in the model registry.", "warning");
-    return;
-  }
-  const options = models.map((model) => {
-    const current = modelLabel(model) === configuredMemoryModel() ? " · current" : "";
-    return `${modelLabel(model)} · ${model.name}${current}`;
-  });
-  const selected = await ctx.ui.select("Select a memory model", options);
-  if (!selected) return;
-  const model = models[options.indexOf(selected)];
-  if (!model) return;
-  saveMemoryConfig({ provider: model.provider, model: model.id });
-  ctx.ui.notify(`Memory model set to ${modelLabel(model)}`, "info");
+  const result = await selectModelFromMenu(
+    ctx.ui,
+    availableMemoryModels(ctx),
+    configuredMemoryModel(),
+    "Select a memory model",
+  );
+  if (!result) return;
+  saveMemoryConfig(result);
+  ctx.ui.notify(`Memory model set to ${result.provider}/${result.model}`, "info");
+}
+
+async function enterMemoryModel(ctx: ExtensionContext): Promise<void> {
+  const result = await enterModelFromInput(ctx.ui, ctx.modelRegistry, modelRef(memoryConfig), { label: "Memory model" });
+  if (!result) return;
+  saveMemoryConfig(result);
+  ctx.ui.notify(`Memory model set to ${result.provider}/${result.model}`, "info");
 }
 
 async function setMemoryModel(value: string, ctx: ExtensionContext): Promise<void> {
@@ -428,12 +429,6 @@ async function setMemoryModel(value: string, ctx: ExtensionContext): Promise<voi
   }
   saveMemoryConfig(ref);
   ctx.ui.notify(`Memory model set to ${ref.provider}/${ref.model}`, "info");
-}
-
-async function enterMemoryModel(ctx: ExtensionContext): Promise<void> {
-  const value = await ctx.ui.input("Memory model", configuredMemoryModel() === "(not configured)" ? "provider/model" : configuredMemoryModel());
-  if (value === undefined) return;
-  await setMemoryModel(value, ctx);
 }
 
 function clearDreamingWidget(ctx: ExtensionContext): void {

--- a/packages/memory/features/consolidate.feature
+++ b/packages/memory/features/consolidate.feature
@@ -7,7 +7,7 @@ Feature: Memory management with auto-memory guidance and manual consolidation
   it only runs on manual user invocation in the background.
 
   Background:
-    Given the @fradser/pi-memory package is installed
+    Given the pi-memory-fradser package is installed
 
   Scenario: Injects auto-memory guidance when auto-memory is on
     Given auto-memory setting is on

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -24,10 +24,13 @@
   ],
   "pi": {
     "extensions": [
-      "./extensions"
+      "./extensions/inject-memory.ts"
     ]
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"
+  },
+  "dependencies": {
+    "@fradser/pi-kit": "workspace:*"
   }
 }

--- a/packages/memory/tests/test_inject_memory_extension.py
+++ b/packages/memory/tests/test_inject_memory_extension.py
@@ -48,13 +48,16 @@ class TestInjectMemoryExtension(unittest.TestCase):
 
     def test_memory_model_configuration_is_available(self):
         content = self.ext_source()
-        self.assertIn('"../config"', content)
+        self.assertIn('"./config"', content)
         self.assertIn("availableMemoryModels", content)
         self.assertIn("chooseMemoryModel", content)
         self.assertIn("enterMemoryModel", content)
         self.assertIn("memoryConfigPath", content)
         self.assertIn('"--model"', content)
-        with open(os.path.join(MEMORY_PKG_DIR, "config.ts"), encoding="utf-8") as f:
+        with open(
+            os.path.join(MEMORY_PKG_DIR, "extensions", "config.ts"),
+            encoding="utf-8",
+        ) as f:
             self.assertIn("PI_MEMORY_MODEL", f.read())
 
     def test_menu_options_contain_auto_memory_toggle(self):
@@ -96,7 +99,9 @@ class TestInjectMemoryExtension(unittest.TestCase):
             data = json.load(f)
         self.assertIn("pi", data)
         self.assertIn("extensions", data["pi"])
-        self.assertIn("./extensions", data["pi"]["extensions"])
+        # The entry is the explicit factory file; config.ts is a helper module,
+        # never a directory glob (pi would otherwise try to load config.ts as an extension).
+        self.assertIn("./extensions/inject-memory.ts", data["pi"]["extensions"])
 
 
 class TestManualConsolidation(unittest.TestCase):

--- a/packages/monitor/README.md
+++ b/packages/monitor/README.md
@@ -33,7 +33,7 @@ wakes the agent once when:
 ## Installation
 
 ```bash
-pi install npm:@fradser/pi-monitor
+pi install npm:pi-monitor-fradser
 # or from this repository:
 pi install /path/to/pi-packages/packages/monitor
 ```

--- a/packages/monitor/features/monitor.feature
+++ b/packages/monitor/features/monitor.feature
@@ -4,7 +4,7 @@ Feature: Result-contract background monitoring
   result instead of streaming raw progress logs to the agent.
 
   Background:
-    Given the @fradser/pi-monitor extension is loaded
+    Given the pi-monitor-fradser extension is loaded
 
   Scenario: Starting a monitor requires a success result contract
     When monitor_start runs with a command, description, and result pattern

--- a/packages/monitor/src/index.ts
+++ b/packages/monitor/src/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import {
   MonitorManager,
   type Monitor,
@@ -14,10 +14,6 @@ const MONITOR_GUIDANCE = `
 - After monitor_start returns, end this turn. Do not sleep, poll, wait, or do follow-up work.
 - Wait for the monitor's terminal result; it will wake you automatically.
 `;
-
-function isEscapeKey(data: string): boolean {
-  return data === "\u001b" || /^\u001b\[27(?:[:;\d]*)?u$/.test(data);
-}
 
 export default function (pi: ExtensionAPI) {
   let requestRender: (() => void) | undefined;
@@ -110,7 +106,7 @@ export default function (pi: ExtensionAPI) {
         invalidate: () => {},
         handleInput: (data: string) => {
           const monitors = manager.listAll();
-          if (isEscapeKey(data) || data === "q" || data === "Q") {
+          if (matchesKey(data, Key.escape) || data === "q" || data === "Q") {
             done();
             return;
           }

--- a/packages/pi-kit/README.md
+++ b/packages/pi-kit/README.md
@@ -1,0 +1,35 @@
+# @fradser/pi-kit
+
+Shared runtime helpers for the FradSer pi-packages monorepo. This is an
+internal workspace dependency, **not** a Pi package: it has no `pi` manifest,
+no skills, and no extensions. Consumer packages declare it as
+`"@fradser/pi-kit": "workspace:*"` under `dependencies`.
+
+## API
+
+### TUI
+
+- `PI_SPINNER_FRAMES` — braille spinner frames identical to pi's native
+  ` ⠋ Working...` loader row.
+- `PI_SPINNER_INTERVAL_MS` — `120`, the native loader cadence.
+- `createPiThemeStyle(theme)` — adapts any pi theme (`{ fg(color, text) }`)
+  to the shared overlay/console style language:
+  `accent` / `muted` / `dim` / `border` / `success` / `error` / `fg`.
+  See `packages/btw` for the canonical layout that consumes it.
+
+### Messages
+
+- `extractTextContent(content, separator = "\n")` — plain text from a pi
+  message content value (string or content-block array). Non-text blocks
+  contribute nothing; callers own trim/empty semantics.
+
+## Rules
+
+- Zero runtime dependencies beyond Node built-ins; no imports of pi core or
+  consumer packages (the dependency graph stays one-way).
+- All code lives in `src/index.ts`: a zero-internal-import module resolves
+  identically under Node's native type stripping, tsx, pi's extension loader,
+  and tsc with any moduleResolution.
+- Do not wrap what `@earendil-works/pi-tui` already exports
+  (`wrapTextWithAnsi`, `truncateToWidth`, `visibleWidth`, `Key`,
+  `matchesKey`, `isKeyRelease`) — consumers import those directly.

--- a/packages/pi-kit/features/pi-kit.feature
+++ b/packages/pi-kit/features/pi-kit.feature
@@ -1,0 +1,80 @@
+Feature: Shared pi-kit runtime helpers
+  As the pi-packages monorepo
+  I want TUI and message helpers shared from one internal runtime package
+  So that spinner cadence, theme style callbacks, and message text extraction
+  stay identical across agent-teams, btw, memory, recap, vision, and utils
+
+  Scenario: Spinner frames match pi's native loader
+    Given a package animates a waiting indicator
+    When it imports the shared spinner constants
+    Then the frames equal pi's native "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏" braille sequence
+    And the shared interval is 120 ms
+
+  Scenario: Theme style language is adapted from any pi theme
+    Given a pi theme object with an fg(color, text) function
+    When the shared theme style is created
+    Then accent, muted, dim, border, success, and error callbacks map to theme fg colors
+    And the fg callback passes arbitrary colors through
+
+  Scenario: Plain text is extracted from string message content
+    Given message content that is a plain string
+    When text content is extracted
+    Then the string is returned unchanged
+
+  Scenario: Plain text is extracted from content-block arrays
+    Given message content with text blocks mixed with image and thinking blocks
+    When text content is extracted
+    Then only text block text is joined, in order, with the requested separator
+    And non-text blocks contribute nothing
+
+  Scenario: Non-message content yields empty text
+    Given content that is neither a string nor an array
+    When text content is extracted
+    Then an empty string is returned
+
+  Scenario: Model reference is parsed from a provider/model string
+    Given a valid "provider/model" string
+    When parseModelRef is called
+    Then it returns the provider and model parts
+
+  Scenario: Model reference returns undefined for invalid input
+    Given an undefined, empty, or malformed value
+    When parseModelRef is called
+    Then it returns undefined
+
+  Scenario: Model reference is formatted from config
+    Given a config with provider and model set
+    When modelRef is called
+    Then it returns "provider/model"
+
+  Scenario: Model label is formatted from a model object
+    Given a model with provider and id
+    When modelLabel is called
+    Then it returns "provider/id"
+
+  Scenario: Models are sorted by provider/id label
+    Given a list of models in arbitrary order
+    When sortModels is called
+    Then the models are ordered by provider/id
+
+  Scenario: A model is selected from the interactive menu
+    Given available models and a current model reference
+    When selectModelFromMenu is called with a mock UI
+    Then it returns the selected provider/model pair
+    And the current model is marked with "current"
+
+  Scenario: Empty model input is returned as undefined
+    Given an empty or cancelled input
+    When enterModelFromInput is called
+    Then it returns undefined
+
+  Scenario: Invalid model input shows an error notification
+    Given a malformed model reference
+    When enterModelFromInput is called
+    Then it notifies with an error and returns undefined
+
+  Scenario: pi-kit stays a pure runtime dependency
+    Given the pi-kit package manifest
+    Then it declares no pi manifest, no dependencies, and no peer dependencies
+    And consumer packages declare it under dependencies with the workspace protocol
+    And the publish allowlist orders pi-kit before its consumers

--- a/packages/pi-kit/package.json
+++ b/packages/pi-kit/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@fradser/pi-kit",
+  "version": "0.1.0",
+  "description": "Shared runtime helpers for FradSer pi packages — TUI spinner/theme primitives and message text extraction. Internal workspace dependency, not a Pi package.",
+  "keywords": [
+    "pi-kit",
+    "pi-packages",
+    "shared-runtime"
+  ],
+  "author": "Frad LEE <fradser@gmail.com>",
+  "license": "MIT",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FradSer/pi-packages.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ]
+}

--- a/packages/pi-kit/src/index.ts
+++ b/packages/pi-kit/src/index.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared runtime helpers for FradSer pi packages.
+ *
+ * Everything lives in this single file on purpose: a zero-internal-import
+ * module resolves identically under Node's native type stripping, tsx, pi's
+ * extension loader, and tsc with any moduleResolution — no extensionless
+ * specifier or allowImportingTsExtensions edge cases.
+ */
+
+// ── TUI ─────────────────────────────────────────────────────────────
+// Spinner cadence matching pi's native " ⠋ Working..." loader and the
+// accent/muted/dim style language used by overlay and console UIs
+// (packages/btw is the canonical layout).
+
+/** Braille spinner frames, identical to pi's native loader row. */
+export const PI_SPINNER_FRAMES: string[] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/** Spinner frame interval matching pi's native loader cadence. */
+export const PI_SPINNER_INTERVAL_MS = 120;
+
+/** Minimal structural view of pi's TUI theme: only fg() is needed. */
+export interface PiThemeLike {
+  fg(color: string, text: string): string;
+}
+
+/** Style callbacks shared by overlay/console UIs (the btw style language). */
+export interface PiThemeStyle {
+  accent: (s: string) => string;
+  muted: (s: string) => string;
+  dim: (s: string) => string;
+  border: (s: string) => string;
+  success: (s: string) => string;
+  error: (s: string) => string;
+  fg: (color: string, text: string) => string;
+}
+
+/** Adapt a pi theme to the shared style-callback language. */
+export function createPiThemeStyle(theme: PiThemeLike): PiThemeStyle {
+  return {
+    accent: (s) => theme.fg("accent", s),
+    muted: (s) => theme.fg("muted", s),
+    dim: (s) => theme.fg("dim", s),
+    border: (s) => theme.fg("border", s),
+    success: (s) => theme.fg("success", s),
+    error: (s) => theme.fg("error", s),
+    fg: (color, s) => theme.fg(color, s),
+  };
+}
+
+// ── Messages ────────────────────────────────────────────────────────
+
+/**
+ * Extract plain text from a pi message content value (string or content-block
+ * array). Non-text blocks (images, tool calls, thinking) contribute nothing.
+ * Returns the joined text, possibly empty; callers own trim/empty semantics.
+ */
+export function extractTextContent(content: unknown, separator = "\n"): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const texts: string[] = [];
+  for (const part of content) {
+    if (typeof part !== "object" || part === null) continue;
+    const block = part as { type?: unknown; text?: unknown };
+    if (block.type === "text" && typeof block.text === "string") texts.push(block.text);
+  }
+  return texts.join(separator);
+}
+
+// ── Model selection ─────────────────────────────────────────────────
+// Shared across memory, recap, and vision for selecting a model from the
+// registry via the interactive TUI menu (ctx.ui.select/input).
+
+/**
+ * Return the trimmed string when it is non-empty, otherwise undefined.
+ * Shared by readConfig functions across packages.
+ */
+export function nonEmpty(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Parse a "provider/model" reference string into its parts. Invalid formats
+ * (no slash, leading/trailing slash, empty) return undefined.
+ */
+export function parseModelRef(
+  value: string | undefined,
+): { provider: string; model: string } | undefined {
+  const ref = nonEmpty(value);
+  if (!ref) return undefined;
+  const separator = ref.indexOf("/");
+  if (separator <= 0 || separator === ref.length - 1) return undefined;
+  return { provider: ref.slice(0, separator), model: ref.slice(separator + 1) };
+}
+
+/**
+ * Format a config's provider and model as "provider/model". Returns the bare
+ * model when only the model is set, or undefined when neither is set.
+ */
+export function modelRef(config: { provider?: string; model?: string }): string | undefined {
+  if (config.provider && config.model) return `${config.provider}/${config.model}`;
+  return config.model;
+}
+
+/** Format a model as "provider/id". */
+export function modelLabel(model: { provider: string; id: string }): string {
+  return `${model.provider}/${model.id}`;
+}
+
+/** Sort models in-place by provider/id label. */
+export function sortModels<T extends { provider: string; id: string }>(models: T[]): T[] {
+  return models.sort((a, b) => modelLabel(a).localeCompare(modelLabel(b)));
+}
+
+/** Minimal UI surface for interactive model selection via ctx.ui.select. */
+export interface MenuUi {
+  select(label: string, options: string[]): Promise<string | undefined>;
+  notify(msg: string, type?: "error" | "info" | "warning"): void;
+}
+
+/** Minimal UI surface for interactive model entry via ctx.ui.input. */
+export interface InputUi {
+  input(label: string, defaultValue?: string): Promise<string | undefined>;
+  notify(msg: string, type?: "error" | "info" | "warning"): void;
+}
+
+/**
+ * Interactive model selection via ctx.ui.select. Pass the available models
+ * (already filtered and sorted by the caller), the current model reference
+ * (for the "current" marker), and an optional title. Returns the selected
+ * provider/model pair, or undefined when the dialog is cancelled or no models
+ * are available.
+ */
+export async function selectModelFromMenu(
+  ui: MenuUi,
+  models: { provider: string; id: string; name: string }[],
+  currentModel: string | undefined,
+  title?: string,
+): Promise<{ provider: string; model: string } | undefined> {
+  if (models.length === 0) {
+    ui.notify("No models are available in the model registry.", "warning");
+    return undefined;
+  }
+  const options = models.map((model) => {
+    const current = modelLabel(model) === currentModel ? " · current" : "";
+    return `${modelLabel(model)} · ${model.name}${current}`;
+  });
+  const selected = await ui.select(title ?? "Select a model", options);
+  if (!selected) return undefined;
+  const model = models[options.indexOf(selected)];
+  if (!model) return undefined;
+  return { provider: model.provider, model: model.id };
+}
+
+/** Options for enterModelFromInput. */
+export interface EnterModelOptions {
+  /** Dialog label shown to the user. */
+  label?: string;
+  /** Called when the user submits empty input (not on cancel). Default: notify an error. */
+  onEmpty?: () => void;
+}
+
+/**
+ * Interactive model entry via ctx.ui.input. Validates the input as a
+ * "provider/model" reference and checks that the model exists in the registry.
+ * Returns the parsed provider/model pair, or undefined when the dialog is
+ * cancelled, the input is empty, or validation fails. Empty input notifies an
+ * error unless an onEmpty handler is provided.
+ */
+export async function enterModelFromInput(
+  ui: InputUi,
+  modelRegistry: { find(provider: string, model: string): unknown },
+  currentModel: string | undefined,
+  options?: EnterModelOptions,
+): Promise<{ provider: string; model: string } | undefined> {
+  const value = await ui.input(
+    options?.label ?? "Model (provider/model format):",
+    currentModel ?? "",
+  );
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) {
+    if (options?.onEmpty) {
+      options.onEmpty();
+    } else {
+      ui.notify(
+        "Enter a model in provider/model format (e.g. anthropic/claude-3-5-haiku)",
+        "error",
+      );
+    }
+    return undefined;
+  }
+  const ref = parseModelRef(trimmed);
+  if (!ref) {
+    ui.notify(
+      "Enter a model in provider/model format (e.g. anthropic/claude-3-5-haiku)",
+      "error",
+    );
+    return undefined;
+  }
+  if (!modelRegistry.find(ref.provider, ref.model)) {
+    ui.notify(
+      `Model ${ref.provider}/${ref.model} was not found in the model registry`,
+      "error",
+    );
+    return undefined;
+  }
+  return ref;
+}

--- a/packages/pi-kit/tests/test_pi_kit.py
+++ b/packages/pi-kit/tests/test_pi_kit.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+PACKAGE = Path(__file__).resolve().parents[1]
+REPO = PACKAGE.parents[1]
+SRC = PACKAGE / "src"
+
+CONSUMERS = [
+    "agent-teams",
+    "btw",
+    "memory",
+    "recap",
+    "utils",
+    "vision",
+]
+
+
+def run_typescript(script: str) -> dict[str, object]:
+    result = subprocess.run(
+        ["node", "--import", "tsx", "--input-type=module"],
+        cwd=REPO,
+        input=textwrap.dedent(script),
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, f"TypeScript runtime check failed:\n{result.stderr}\n{result.stdout}"
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_feature_covers_spinner_theme_messages_and_dependency_hygiene() -> None:
+    feature = (PACKAGE / "features" / "pi-kit.feature").read_text(encoding="utf-8")
+    assert "Feature: Shared pi-kit runtime helpers" in feature
+    assert "Scenario: Spinner frames match pi's native loader" in feature
+    assert "Scenario: Theme style language is adapted from any pi theme" in feature
+    assert "Scenario: Plain text is extracted from string message content" in feature
+    assert "Scenario: Plain text is extracted from content-block arrays" in feature
+    assert "Scenario: Non-message content yields empty text" in feature
+    assert "Scenario: Model reference is parsed from a provider/model string" in feature
+    assert "Scenario: Model reference is formatted from config" in feature
+    assert "Scenario: Model label is formatted from a model object" in feature
+    assert "Scenario: A model is selected from the interactive menu" in feature
+    assert "Scenario: pi-kit stays a pure runtime dependency" in feature
+
+
+def test_spinner_constants_match_pi_native_loader() -> None:
+    result = run_typescript(
+        f"""
+        import {{ PI_SPINNER_FRAMES, PI_SPINNER_INTERVAL_MS }} from {json.dumps((SRC / "index.ts").as_uri())};
+        console.log(JSON.stringify({{ frames: PI_SPINNER_FRAMES, interval: PI_SPINNER_INTERVAL_MS }}));
+        """
+    )
+    assert result["frames"] == ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    assert result["interval"] == 120
+
+
+def test_theme_style_maps_shared_style_language() -> None:
+    result = run_typescript(
+        f"""
+        import {{ createPiThemeStyle }} from {json.dumps((SRC / "index.ts").as_uri())};
+        const theme = {{ fg: (color, text) => `[${{color}}]${{text}}` }};
+        const style = createPiThemeStyle(theme);
+        console.log(JSON.stringify({{
+          accent: style.accent("a"),
+          muted: style.muted("m"),
+          dim: style.dim("d"),
+          border: style.border("b"),
+          success: style.success("s"),
+          error: style.error("e"),
+          fg: style.fg("warning", "w"),
+        }}));
+        """
+    )
+    assert result == {
+        "accent": "[accent]a",
+        "muted": "[muted]m",
+        "dim": "[dim]d",
+        "border": "[border]b",
+        "success": "[success]s",
+        "error": "[error]e",
+        "fg": "[warning]w",
+    }
+
+
+def test_extract_text_content_from_strings_blocks_and_non_content() -> None:
+    result = run_typescript(
+        f"""
+        import {{ extractTextContent }} from {json.dumps((SRC / "index.ts").as_uri())};
+        const blocks = [
+          {{ type: "text", text: "first" }},
+          {{ type: "image", data: "..." }},
+          {{ type: "thinking", thinking: "secret" }},
+          {{ type: "text", text: "second" }},
+        ];
+        console.log(JSON.stringify({{
+          fromString: extractTextContent("hello"),
+          fromBlocks: extractTextContent(blocks),
+          joinedEmpty: extractTextContent(blocks, ""),
+          joinedSpace: extractTextContent(blocks, " "),
+          fromNull: extractTextContent(null),
+          fromNumber: extractTextContent(42),
+          fromEmptyArray: extractTextContent([]),
+        }}));
+        """
+    )
+    assert result == {
+        "fromString": "hello",
+        "fromBlocks": "first\nsecond",
+        "joinedEmpty": "firstsecond",
+        "joinedSpace": "first second",
+        "fromNull": "",
+        "fromNumber": "",
+        "fromEmptyArray": "",
+    }
+
+
+def test_model_ref_parse_and_format_helpers() -> None:
+    result = run_typescript(
+        f"""
+        import {{ parseModelRef, modelRef, modelLabel, sortModels, nonEmpty }} from {json.dumps((SRC / "index.ts").as_uri())};
+        console.log(JSON.stringify({{
+          parsed: parseModelRef("anthropic/claude-3-5-haiku"),
+          parsedModelOnly: parseModelRef("openai/gpt-4o-mini"),
+          invalidNoSlash: parseModelRef("gpt-4o"),
+          invalidEmpty: parseModelRef(""),
+          invalidUndefined: parseModelRef(undefined),
+          invalidLeadingSlash: parseModelRef("/gpt-4o"),
+          invalidTrailingSlash: parseModelRef("openai/"),
+          refBoth: modelRef({{ provider: "openai", model: "gpt-4o" }}),
+          refModelOnly: modelRef({{ provider: undefined, model: "gpt-4o" }}),
+          refNone: modelRef({{ provider: undefined, model: undefined }}),
+          label: modelLabel({{ provider: "anthropic", id: "claude" }}),
+          sorted: sortModels([
+            {{ provider: "z", id: "a" }},
+            {{ provider: "a", id: "z" }},
+            {{ provider: "a", id: "a" }},
+          ]),
+          nonEmpty: nonEmpty("  hi  "),
+          nonEmptyBlank: nonEmpty("   "),
+        }}, (k, v) => (v === undefined ? null : v)));
+        """
+    )
+    assert result["parsed"] == {"provider": "anthropic", "model": "claude-3-5-haiku"}
+    assert result["parsedModelOnly"] == {"provider": "openai", "model": "gpt-4o-mini"}
+    assert result["invalidNoSlash"] is None
+    assert result["invalidEmpty"] is None
+    assert result["invalidUndefined"] is None
+    assert result["invalidLeadingSlash"] is None
+    assert result["invalidTrailingSlash"] is None
+    assert result["refBoth"] == "openai/gpt-4o"
+    assert result["refModelOnly"] == "gpt-4o"
+    assert result["refNone"] is None
+    assert result["label"] == "anthropic/claude"
+    assert result["sorted"] == [
+        {"provider": "a", "id": "a"},
+        {"provider": "a", "id": "z"},
+        {"provider": "z", "id": "a"},
+    ]
+    assert result["nonEmpty"] == "hi"
+    assert result["nonEmptyBlank"] is None
+
+
+def test_select_model_from_menu_returns_selected_pair() -> None:
+    result = run_typescript(
+        f"""
+        import {{ selectModelFromMenu }} from {json.dumps((SRC / "index.ts").as_uri())};
+        const ui = {{
+          notify: () => {{}},
+          select: async (label, options) => {{
+            // Simulate the user picking the "current" option.
+            return options.find((o) => o.includes("· current"));
+          }},
+        }};
+        const models = [
+          {{ provider: "anthropic", id: "claude-sonnet", name: "Claude Sonnet" }},
+          {{ provider: "openai", id: "gpt-4o", name: "GPT-4o" }},
+        ];
+        const selected = await selectModelFromMenu(ui, models, "anthropic/claude-sonnet", "Pick");
+        console.log(JSON.stringify({{ selected }}));
+        """
+    )
+    assert result["selected"] == {"provider": "anthropic", "model": "claude-sonnet"}
+
+
+def test_select_model_menu_no_models_notifies_and_returns_undefined() -> None:
+    result = run_typescript(
+        f"""
+        import {{ selectModelFromMenu }} from {json.dumps((SRC / "index.ts").as_uri())};
+        let notified = null;
+        const ui = {{ select: async () => "x", notify: (msg, type) => {{ notified = {{ msg, type }}; }} }};
+        const selected = await selectModelFromMenu(ui, [], undefined, "Pick");
+        console.log(JSON.stringify({{ selected, notified }}, (k, v) => (v === undefined ? null : v)));
+        """
+    )
+    assert result["selected"] is None
+    assert result["notified"] == {"msg": "No models are available in the model registry.", "type": "warning"}
+
+
+def test_enter_model_from_input_parses_and_validates() -> None:
+    result = run_typescript(
+        f"""
+        import {{ enterModelFromInput }} from {json.dumps((SRC / "index.ts").as_uri())};
+        const registry = {{ find: (p, m) => (p === "openai" && m === "gpt-4o" ? {{}} : undefined) }};
+        const notifications = [];
+        const ui = {{
+          notify: (msg, type) => notifications.push({{ msg, type }}),
+        }};
+        const good = await enterModelFromInput({{ ...ui, input: async () => "openai/gpt-4o" }}, registry, undefined);
+        const bad = await enterModelFromInput({{ ...ui, input: async () => "nope" }}, registry, undefined);
+        const missing = await enterModelFromInput({{ ...ui, input: async () => "openai/unknown" }}, registry, undefined);
+        const empty = await enterModelFromInput({{ ...ui, input: async () => "   " }}, registry, undefined);
+        const cancelled = await enterModelFromInput({{ ...ui, input: async () => undefined }}, registry, undefined);
+        console.log(JSON.stringify({{ good, bad, missing, empty, cancelled, notifications }}, (k, v) => (v === undefined ? null : v)));
+        """
+    )
+    assert result["good"] == {"provider": "openai", "model": "gpt-4o"}
+    assert result["bad"] is None
+    assert result["missing"] is None
+    assert result["empty"] is None
+    assert result["cancelled"] is None
+    assert len(result["notifications"]) == 3
+    assert result["notifications"][0]["type"] == "error"
+    assert result["notifications"][1]["type"] == "error"
+    assert result["notifications"][2]["type"] == "error"
+
+
+def test_enter_model_population_and_on_empty_handler() -> None:
+    result = run_typescript(
+        f"""
+        import {{ enterModelFromInput }} from {json.dumps((SRC / "index.ts").as_uri())};
+        const registry = {{ find: (p) => (p === "openai" ? {{}} : undefined) }};
+        const notifications = [];
+        const ui = {{ notify: (msg, type) => notifications.push({{ msg, type }}) }};
+        let reset = 0;
+        const empty = await enterModelFromInput(
+          {{ ...ui, input: async () => "   " }},
+          registry, undefined,
+          {{ onEmpty: () => {{ reset++; }} }},
+        );
+        const defaulted = await enterModelFromInput(
+          {{ ...ui, input: async (label, def) => def }},
+          registry, "openai/gpt-4o",
+          {{ label: "Pick me" }},
+        );
+        console.log(JSON.stringify({{ empty, reset, defaulted, notifications }}, (k, v) => (v === undefined ? null : v)));
+        """
+    )
+    assert result["empty"] is None
+    assert result["reset"] == 1
+    assert result["defaulted"] == {"provider": "openai", "model": "gpt-4o"}
+    # onEmpty suppresses the error notification.
+    assert result["notifications"] == []
+
+
+def test_pi_kit_manifest_is_a_pure_runtime_dependency() -> None:
+    manifest = json.loads((PACKAGE / "package.json").read_text(encoding="utf-8"))
+    assert manifest["name"] == "@fradser/pi-kit"
+    assert "pi" not in manifest
+    assert "dependencies" not in manifest
+    assert "peerDependencies" not in manifest
+    assert "pi-package" not in manifest.get("keywords", [])
+    assert "src" in manifest["files"]
+
+
+def test_pi_kit_has_no_consumer_imports() -> None:
+    consumer_names = {json.loads((REPO / "packages" / c / "package.json").read_text())["name"] for c in CONSUMERS}
+    for source in SRC.glob("*.ts"):
+        text = source.read_text(encoding="utf-8")
+        for name in consumer_names:
+            assert name not in text, f"{source.name} must not import consumer package {name}"
+        assert "@earendil-works" not in text, f"{source.name} must stay free of pi core imports"
+
+
+def test_consumers_declare_pi_kit_as_workspace_dependency() -> None:
+    for consumer in CONSUMERS:
+        manifest = json.loads((REPO / "packages" / consumer / "package.json").read_text(encoding="utf-8"))
+        assert manifest.get("dependencies", {}).get("@fradser/pi-kit") == "workspace:*", (
+            f"{consumer} must depend on @fradser/pi-kit via workspace:* under dependencies"
+        )
+        assert "@fradser/pi-kit" not in manifest.get("peerDependencies", {}), (
+            f"{consumer} must not declare @fradser/pi-kit as a peer dependency"
+        )
+
+
+def test_publish_allowlist_orders_pi_kit_before_consumers() -> None:
+    script = (REPO / "scripts" / "publish-release.mjs").read_text(encoding="utf-8")
+    kit_position = script.index('"@fradser/pi-kit"')
+    assert kit_position > 0, "publish allowlist must include @fradser/pi-kit"
+    for name in ['"@fradser/pi-agent-teams"', '"@fradser/pi-btw"', '"@fradser/pi-memory"',
+                 '"@fradser/pi-recap"', '"@fradser/pi-utils"', '"@fradser/pi-vision"']:
+        assert script.index(name) > kit_position, f"pi-kit must publish before {name}"

--- a/packages/pi-kit/tsconfig.json
+++ b/packages/pi-kit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/recap/README.md
+++ b/packages/recap/README.md
@@ -1,11 +1,11 @@
-# @fradser/pi-recap
+# pi-recap-fradser
 
 Session recap for Pi — displays a concise, scannable summary of the current session above the TUI input box, inspired by Claude Code's `✦ Recap:` feature.
 
 ## Install
 
 ```bash
-pi install npm:@fradser/pi-recap
+pi install npm:pi-recap-fradser
 ```
 
 ## Features

--- a/packages/recap/extensions/config.ts
+++ b/packages/recap/extensions/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import { dirname, join } from "node:path";
+import { nonEmpty, parseModelRef } from "@fradser/pi-kit";
 
 export type RecapLanguage = "auto" | "zh" | "en" | string;
 
@@ -20,29 +21,6 @@ function getAgentDir(): string {
 }
 
 const CONFIG_PATH = join(getAgentDir(), "recap.json");
-
-function nonEmpty(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-export function parseModelRef(
-  value: string | undefined,
-): { provider: string; model: string } | undefined {
-  const ref = nonEmpty(value);
-  if (!ref) return undefined;
-  const separator = ref.indexOf("/");
-  if (separator <= 0 || separator === ref.length - 1) return undefined;
-  return {
-    provider: ref.slice(0, separator),
-    model: ref.slice(separator + 1),
-  };
-}
-
-export function modelRef(config: RecapConfig): string | undefined {
-  if (config.provider && config.model)
-    return `${config.provider}/${config.model}`;
-  return config.model;
-}
 
 export function languageLabel(lang: RecapLanguage | undefined): string {
   const l = (lang || "auto").toLowerCase();

--- a/packages/recap/extensions/index.ts
+++ b/packages/recap/extensions/index.ts
@@ -19,9 +19,15 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import {
-  languageLabel,
+  enterModelFromInput,
   modelRef,
   parseModelRef,
+  PI_SPINNER_FRAMES,
+  selectModelFromMenu,
+  sortModels,
+} from "@fradser/pi-kit";
+import {
+  languageLabel,
   type RecapConfig,
   readRecapConfig,
   recapConfigPath,
@@ -35,30 +41,18 @@ import {
 } from "./recap";
 
 let config: RecapConfig = readRecapConfig();
-const RECAP_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 function configuredModelLabel(): string {
   return modelRef(config) ?? "(session default)";
 }
 
-function modelLabel(model: Model<Api>): string {
-  return `${model.provider}/${model.id}`;
-}
-
-function modelOptionLabel(model: Model<Api>): string {
-  const current = modelLabel(model) === modelRef(config) ? " · current" : "";
-  return `${modelLabel(model)} · ${model.name}${current}`;
-}
-
-function availableModels(ctx: ExtensionContext): Model<Api>[] {
+function availableModels(ctx: ExtensionContext) {
   const currentPiModels =
     ctx.scopedModels && ctx.scopedModels.length > 0
       ? ctx.scopedModels.map((scoped) => scoped.model)
       : ctx.modelRegistry.getAvailable();
 
-  return [...currentPiModels].sort((left, right) =>
-    modelLabel(left).localeCompare(modelLabel(right)),
-  );
+  return sortModels([...currentPiModels]);
 }
 
 function resolveRecapModel(ctx: ExtensionContext): Model<Api> | undefined {
@@ -172,7 +166,7 @@ export default function (pi: ExtensionAPI) {
           recapSpinnerFrame = 0;
           recapSpinnerTimer = setInterval(() => {
             recapSpinnerFrame =
-              (recapSpinnerFrame + 1) % RECAP_SPINNER_FRAMES.length;
+              (recapSpinnerFrame + 1) % PI_SPINNER_FRAMES.length;
             tui.requestRender();
           }, 80);
           recapSpinnerTimer.unref?.();
@@ -191,7 +185,7 @@ export default function (pi: ExtensionAPI) {
             const lines: string[] = [];
 
             if (generatingRecap) {
-              const spinner = RECAP_SPINNER_FRAMES[recapSpinnerFrame];
+              const spinner = PI_SPINNER_FRAMES[recapSpinnerFrame];
               lines.push(` ${theme.fg("accent", `${spinner} Recapping...`)}`);
             }
 
@@ -290,62 +284,36 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function chooseRecapModel(ctx: ExtensionCommandContext): Promise<void> {
-    const models = availableModels(ctx);
-    if (models.length === 0) {
-      ctx.ui.notify("No models found in model registry.", "warning");
-      return;
-    }
-
-    const options = models.map(modelOptionLabel);
-    const selected = await ctx.ui.select(
+    const result = await selectModelFromMenu(
+      ctx.ui,
+      availableModels(ctx),
+      modelRef(config),
       "Select a model for recap generation:",
-      options,
     );
-    if (!selected) return;
 
-    const model = models[options.indexOf(selected)];
-    if (!model) return;
+    if (!result) return;
 
-    saveConfig({ ...config, provider: model.provider, model: model.id }, ctx);
-    ctx.ui.notify(`Recap model set to ${modelLabel(model)}`, "info");
+    saveConfig({ ...config, ...result }, ctx);
+    ctx.ui.notify(`Recap model set to ${result.provider}/${result.model}`, "info");
   }
 
   async function enterRecapModel(ctx: ExtensionCommandContext): Promise<void> {
-    const value = await ctx.ui.input(
-      "Recap model (provider/model format):",
-      config.provider && config.model
-        ? `${config.provider}/${config.model}`
-        : "",
+    const result = await enterModelFromInput(
+      ctx.ui,
+      ctx.modelRegistry,
+      modelRef(config),
+      {
+        label: "Recap model (provider/model format):",
+        onEmpty: () => {
+          saveConfig({ ...config, provider: undefined, model: undefined }, ctx);
+          ctx.ui.notify("Recap model reset to session default", "info");
+        },
+      },
     );
-    if (value === undefined) return; // cancelled
+    if (!result) return;
 
-    const trimmed = value.trim();
-    if (!trimmed) {
-      saveConfig({ ...config, provider: undefined, model: undefined }, ctx);
-      ctx.ui.notify("Recap model reset to session default", "info");
-      return;
-    }
-
-    const ref = parseModelRef(trimmed);
-    if (!ref) {
-      ctx.ui.notify(
-        "Enter a model in provider/model format (e.g. anthropic/claude-3-5-haiku)",
-        "error",
-      );
-      return;
-    }
-
-    const model = ctx.modelRegistry.find(ref.provider, ref.model);
-    if (!model) {
-      ctx.ui.notify(
-        `Model ${ref.provider}/${ref.model} was not found in the model registry`,
-        "error",
-      );
-      return;
-    }
-
-    saveConfig({ ...config, ...ref }, ctx);
-    ctx.ui.notify(`Recap model set to ${modelLabel(model)}`, "info");
+    saveConfig({ ...config, ...result }, ctx);
+    ctx.ui.notify(`Recap model set to ${result.provider}/${result.model}`, "info");
   }
 
   async function chooseRecapLanguage(
@@ -611,7 +579,7 @@ export default function (pi: ExtensionAPI) {
           return;
         }
         saveConfig({ ...config, ...ref }, ctx);
-        ctx.ui.notify(`Recap model set to ${modelLabel(model)}`, "info");
+        ctx.ui.notify(`Recap model set to ${ref.provider}/${ref.model}`, "info");
         return;
       }
 

--- a/packages/recap/extensions/index.ts
+++ b/packages/recap/extensions/index.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-recap — session recap for Pi.
+ * pi-recap-fradser — session recap for Pi.
  *
  * Automatically displays a scannable one-line recap of the current session
  * above the TUI input box (aboveEditor widget), inspired by Claude Code's recap.

--- a/packages/recap/extensions/recap.ts
+++ b/packages/recap/extensions/recap.ts
@@ -10,6 +10,7 @@ import type {
   UserMessage,
 } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { extractTextContent } from "@fradser/pi-kit";
 
 /** Minimal structural view of a session message entry. */
 export const RECAP_TIMEOUT_MS = 30_000;
@@ -58,22 +59,7 @@ export function extractMessageText(
   if (entry.type !== "message") return undefined;
   const msg = entry.message;
   if (!msg) return undefined;
-  const content = msg.content;
-  if (typeof content === "string") return content.trim() || undefined;
-  if (Array.isArray(content)) {
-    const text = content
-      .filter(
-        (part): part is { type?: string; text?: string } =>
-          typeof part === "object" && part !== null && "type" in part,
-      )
-      .map((part) =>
-        part.type === "text" && typeof part.text === "string" ? part.text : "",
-      )
-      .join("\n")
-      .trim();
-    return text || undefined;
-  }
-  return undefined;
+  return extractTextContent(msg.content).trim() || undefined;
 }
 
 /**

--- a/packages/recap/extensions/recap.ts
+++ b/packages/recap/extensions/recap.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-recap — pure recap generation helpers.
+ * pi-recap-fradser — pure recap generation helpers.
  */
 
 import type {

--- a/packages/recap/features/recap.feature
+++ b/packages/recap/features/recap.feature
@@ -7,7 +7,7 @@ Feature: Session Recap
   select custom models, and configure language preferences.
 
   Background:
-    Given the @fradser/pi-recap package is installed
+    Given the pi-recap-fradser package is installed
 
   Scenario: Recap widget is displayed above the editor by default
     Given an active session in TUI mode

--- a/packages/recap/package.json
+++ b/packages/recap/package.json
@@ -31,5 +31,8 @@
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"
+  },
+  "dependencies": {
+    "@fradser/pi-kit": "workspace:*"
   }
 }

--- a/packages/recap/tests/test_recap_package.py
+++ b/packages/recap/tests/test_recap_package.py
@@ -11,6 +11,7 @@ EXTENSIONS = PACKAGE / "extensions"
 RECAP_URI = (EXTENSIONS / "recap.ts").as_uri()
 INDEX_URI = (EXTENSIONS / "index.ts").as_uri()
 CONFIG_URI = (EXTENSIONS / "config.ts").as_uri()
+PIKIT_URI = (REPO / "packages" / "pi-kit" / "src" / "index.ts").as_uri()
 
 
 def run_typescript(script: str) -> dict[str, object]:
@@ -398,7 +399,9 @@ def test_extension_registers_recap_command_with_menu() -> None:
     assert "enterRecapModel" in extension
     assert "chooseRecapLanguage" in extension
     assert "Recapping..." in extension
-    assert "RECAP_SPINNER_FRAMES" in extension
+    assert 'from "@fradser/pi-kit"' in extension
+    assert "PI_SPINNER_FRAMES" in extension
+    assert "PI_SPINNER_FRAMES[recapSpinnerFrame]" in extension
     assert "requestRender" in extension
     assert "generatingRecap" in extension
     assert "same visual column as the native working spinner" in (PACKAGE / "features" / "recap.feature").read_text(encoding="utf-8")
@@ -556,7 +559,8 @@ def test_environment_overrides_take_precedence_over_saved_config() -> None:
 def test_config_parsing_and_model_ref() -> None:
     result = run_typescript(
         f"""
-        import {{ parseModelRef, modelRef, readRecapConfig, languageLabel }} from "{CONFIG_URI}";
+        import {{ readRecapConfig, languageLabel }} from "{CONFIG_URI}";
+        import {{ parseModelRef, modelRef }} from "{PIKIT_URI}";
 
         const parsed1 = parseModelRef("anthropic/claude-3-5-haiku");
         const parsed2 = parseModelRef("invalid-ref");

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -6,7 +6,7 @@ A pi-native package offering `/effort` for setting model thinking levels, `/ç»§ç
 
 ```bash
 # published
-pi install npm:@fradser/pi-utils
+pi install npm:pi-utils-fradser
 # or from this repo: pi install /path/to/pi-packages/packages/utils
 ```
 

--- a/packages/utils/extensions/continue.ts
+++ b/packages/utils/extensions/continue.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-utils — native pi /continue command and continuation input interception.
+ * pi-utils-fradser — native pi /continue command and continuation input interception.
  *
  * Intercepts plain text continuation requests ("continue" / "继续" / "繼續").
  *

--- a/packages/utils/extensions/continue.ts
+++ b/packages/utils/extensions/continue.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { extractTextContent } from "@fradser/pi-kit";
 
 export interface ContinuationTarget {
   promptText: string;
@@ -51,11 +52,7 @@ function getLastUserPrompt(ctx: ExtensionContext): string | null {
         return content;
       }
       if (Array.isArray(content)) {
-        const textParts = content
-          .filter((c): c is { type: "text"; text: string } => c.type === "text")
-          .map((c) => c.text)
-          .join("\n")
-          .trim();
+        const textParts = extractTextContent(content).trim();
         if (textParts) return textParts;
       }
     }
@@ -182,11 +179,7 @@ function resolvePendingContinuation(ctx: ExtensionContext): ContinuationDecision
 
 function resolveToolErrorContinuation(message: Extract<ContinuationMessage, { role: "toolResult" }>): ContinuationDecision {
   const toolName = message.toolName ? ` (${message.toolName})` : "";
-  const errorText = message.content
-    ?.filter((part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text)
-    .join(" ")
-    .toLowerCase() ?? "";
+  const errorText = extractTextContent(message.content, " ").toLowerCase();
 
   if (/response hit the output token limit|arguments may be truncated|re-issue the tool call/.test(errorText)) {
     return {

--- a/packages/utils/extensions/effort.ts
+++ b/packages/utils/extensions/effort.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-utils — native pi /effort command.
+ * pi-utils-fradser — native pi /effort command.
  *
  * Set the session thinking (reasoning effort) level without opening /model:
  *

--- a/packages/utils/extensions/init.ts
+++ b/packages/utils/extensions/init.ts
@@ -1,0 +1,93 @@
+/**
+ * pi-utils — repository contributor-guide initialization command.
+ *
+ * /init delegates repository inspection and AGENTS.md maintenance to the
+ * active agent so the generated guidance reflects the actual project.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const INIT_PROMPT = `
+Generate and maintain contributor guidance for this repository.
+
+Starting directory: __REPOSITORY_ROOT__
+
+First identify the actual repository root when this directory is inside a Git
+checkout (for example with git rev-parse --show-toplevel). Treat the current working directory as the active scope for ./AGENTS.md, and
+inspect all existing instruction files across the repository before editing
+anything. Use find (excluding generated and vendor directories) to discover
+scoped guides. Determine the project structure,
+source and test locations, assets, package manifests, development/build/test
+commands, formatting and naming conventions, test conventions, recent commit
+message patterns, and pull-request expectations. Use the repository's actual
+files and git history instead of guessing. Do not edit generated files,
+dependencies, secrets, or unrelated source code.
+
+Instruction-file scope and safety:
+- Find all existing AGENTS.md files below the actual repository root, excluding
+  .git, node_modules, build output, caches, and other generated/vendor
+  directories. Do not skip an existing guide merely because it is nested.
+- Also check for CLAUDE.md files because they may describe the same project
+  scope. Treat AGENTS.md as the preferred name for new or migrated guidance.
+- Treat each AGENTS.md as an independent scope. Pi automatically applies the
+  applicable files by directory, so do not add parent-file references,
+  inheritance notes, duplicated root rules, or cross-file synchronization prose.
+- If ./AGENTS.md already exists, update it in place only when the repository
+  evidence shows a stale or missing section; do not overwrite it wholesale or
+  discard useful project-specific instructions. If it is already accurate,
+  leave it unchanged.
+- For nested AGENTS.md files, update only the rules specific to that directory.
+  Do not rewrite them to describe the whole repository or create one merely to
+  repeat a parent scope. Preserve genuinely independent guidance.
+- If no applicable guide exists in a scope, create AGENTS.md there only when
+  that scope has meaningful, directory-specific contributor instructions.
+
+Repository-wide package rule:
+- Prefer the internal @fradser/pi-kit workspace runtime for shared reusable
+  helpers and Pi-package infrastructure when it is available. Use
+  "@fradser/pi-kit": "workspace:*" under dependencies, never
+  peerDependencies. If pi-kit is absent, do not invent a replacement or add
+  an unverified registry dependency; record the gap instead.
+
+For each guide you create or update:
+- Use the title "Repository Guidelines".
+- Use clear Markdown headings and concise, actionable explanations.
+- Aim for 200-400 words for a repository-level guide; keep nested guides
+  shorter and focused on their directory.
+- Cover Project Structure & Module Organization, Build/Test/Development
+  Commands, Coding Style & Naming Conventions, Testing Guidelines, and
+  Commit & Pull Request Guidelines when relevant to that scope. Add Security,
+  Configuration, Architecture, or Agent-Specific Instructions only when
+  supported by repository evidence.
+- Include concrete commands and paths where helpful.
+- Keep a professional, instructional tone. Do not claim tools, workflows, or
+  policies that you did not verify.
+
+After editing, briefly report which instruction files were created or updated
+and the independent directory scope each file covers.
+`.trim();
+
+export function buildInitPrompt(cwd: string, focus: string = ""): string {
+  const repositoryRoot = JSON.stringify(cwd);
+  const focusSection = focus.trim()
+    ? `\n\nAdditional user focus (apply only when consistent with the repository evidence above):\n${focus.trim()}`
+    : "";
+
+  return `${INIT_PROMPT.replace("__REPOSITORY_ROOT__", repositoryRoot)}${focusSection}`;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("init", {
+    description: "Create or update scoped AGENTS.md contributor guides for the repository",
+    handler: async (args, ctx) => {
+      const prompt = buildInitPrompt(ctx.cwd, args);
+
+      if (ctx.isIdle()) {
+        pi.sendUserMessage(prompt);
+      } else {
+        pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+        ctx.ui.notify("Repository guide task queued as a follow-up", "info");
+      }
+    },
+  });
+}

--- a/packages/utils/extensions/sessions.ts
+++ b/packages/utils/extensions/sessions.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-utils — cross-session awareness and directory recap extension.
+ * pi-utils-fradser — cross-session awareness and directory recap extension.
  *
  * Provides multi-session awareness for Pi sessions operating in the same project directory.
  * - Registers session status, latest goal, and recap in ~/.pi/agent/directory-sessions/

--- a/packages/utils/extensions/worktree.ts
+++ b/packages/utils/extensions/worktree.ts
@@ -1,5 +1,5 @@
 /**
- * @fradser/pi-utils — git worktree path redirect.
+ * pi-utils-fradser — git worktree path redirect.
  *
  * Intercepts simple `git worktree add` bash tool calls and rewrites the target
  * path to live inside `.pi/worktrees/<name>`. Commands with shell constructs

--- a/packages/utils/features/continue.feature
+++ b/packages/utils/features/continue.feature
@@ -4,7 +4,7 @@ Feature: /continue recovery for incomplete and failed turns
   incomplete turn.
 
   Background:
-    Given the @fradser/pi-utils package is installed
+    Given the pi-utils-fradser package is installed
 
   Scenario: A transient model API request fails after retries are exhausted
     Given the latest assistant message has stopReason "error"

--- a/packages/utils/features/effort.feature
+++ b/packages/utils/features/effort.feature
@@ -5,7 +5,7 @@ Feature: /effort thinking-level command
   directly (with short aliases). The manifest registers it as an extension.
 
   Background:
-    Given the @fradser/pi-utils package is installed
+    Given the pi-utils-fradser package is installed
 
   Scenario: Manifest registers the extensions directory
     Given the package manifest

--- a/packages/utils/features/init.feature
+++ b/packages/utils/features/init.feature
@@ -10,6 +10,7 @@ Feature: /init repository guidelines command
     Then the command sends an instruction to inspect the repository structure,
       commands, tests, style, history, and existing instruction files
     And the instruction asks for a concise "Repository Guidelines" document
+    And the instruction says to prefer pi-kit for shared reusable logic when available
 
   Scenario: /init updates an existing current-directory guide safely
     Given ./AGENTS.md already exists
@@ -17,12 +18,12 @@ Feature: /init repository guidelines command
     Then the instruction tells the agent to preserve useful guidance and update
       the existing document in place instead of replacing it blindly
 
-  Scenario: /init keeps nested guides consistent with their parent scope
+  Scenario: /init treats nested guides as independent scopes
     Given AGENTS.md files exist in the repository root and nested directories
     When the user runs /init
     Then the instruction tells the agent to discover all scoped guides
-    And update only guides relevant to the repository changes
-    And explain parent-child scope relationships without duplicating content
+    And update only guides relevant to each directory
+    And avoid adding inheritance references or duplicating parent instructions
 
   Scenario: /init accepts optional focus from the user
     When the user runs /init focus on package release commands

--- a/packages/utils/features/init.feature
+++ b/packages/utils/features/init.feature
@@ -1,0 +1,29 @@
+Feature: /init repository guidelines command
+  The utils package exposes a pi-native /init command that asks the agent to
+  create or update scoped AGENTS.md contributor guides for the current repository.
+
+  Background:
+    Given the pi-utils package is installed
+
+  Scenario: /init asks the agent to inspect the repository before writing
+    When the user runs /init
+    Then the command sends an instruction to inspect the repository structure,
+      commands, tests, style, history, and existing instruction files
+    And the instruction asks for a concise "Repository Guidelines" document
+
+  Scenario: /init updates an existing current-directory guide safely
+    Given ./AGENTS.md already exists
+    When the user runs /init
+    Then the instruction tells the agent to preserve useful guidance and update
+      the existing document in place instead of replacing it blindly
+
+  Scenario: /init keeps nested guides consistent with their parent scope
+    Given AGENTS.md files exist in the repository root and nested directories
+    When the user runs /init
+    Then the instruction tells the agent to discover all scoped guides
+    And update only guides relevant to the repository changes
+    And explain parent-child scope relationships without duplicating content
+
+  Scenario: /init accepts optional focus from the user
+    When the user runs /init focus on package release commands
+    Then the additional focus is included in the instruction sent to the agent

--- a/packages/utils/features/sessions.feature
+++ b/packages/utils/features/sessions.feature
@@ -6,7 +6,7 @@ Feature: Cross-session awareness and directory recap
   command and a session recap tool for agents to query.
 
   Background:
-    Given the @fradser/pi-utils package is installed
+    Given the pi-utils-fradser package is installed
 
   Scenario: Session registers state in directory registry on startup
     Given a session starting in directory "/app/my-project"

--- a/packages/utils/features/worktree.feature
+++ b/packages/utils/features/worktree.feature
@@ -5,7 +5,7 @@ Feature: git worktree path redirect
   instead of scattering sibling directories next to it.
 
   Background:
-    Given the @fradser/pi-utils package is installed
+    Given the pi-utils-fradser package is installed
 
   Scenario: A `git worktree add` path is redirected into .pi/worktrees
     Given the agent runs `git worktree add ../foo feature/foo`

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,5 +34,8 @@
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"
+  },
+  "dependencies": {
+    "@fradser/pi-kit": "workspace:*"
   }
 }

--- a/packages/utils/tests/test_init_extension.py
+++ b/packages/utils/tests/test_init_extension.py
@@ -1,0 +1,68 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+UTILS_PKG_DIR = Path(__file__).resolve().parents[1]
+REPO = UTILS_PKG_DIR.parents[1]
+INIT_EXTENSION = UTILS_PKG_DIR / "extensions" / "init.ts"
+
+
+class TestInitExtension(unittest.TestCase):
+    def ext_source(self) -> str:
+        return INIT_EXTENSION.read_text(encoding="utf-8")
+
+    def test_extension_file_exists_and_registers_command(self) -> None:
+        self.assertTrue(INIT_EXTENSION.exists())
+        content = self.ext_source()
+        self.assertIn('registerCommand("init"', content)
+        self.assertIn("buildInitPrompt", content)
+        self.assertIn("sendUserMessage", content)
+
+    def test_prompt_covers_repository_guides_and_nested_scopes(self) -> None:
+        content = self.ext_source()
+        for phrase in (
+            "Repository Guidelines",
+            "find",
+            "AGENTS.md",
+            "current working directory",
+            "nested",
+            "independent scope",
+            "do not overwrite",
+            "200-400 words",
+            "git history",
+            "pi-kit",
+        ):
+            self.assertIn(phrase, content)
+
+    def test_prompt_includes_cwd_and_optional_focus(self) -> None:
+        script = f'''
+import {{ buildInitPrompt }} from {json.dumps(INIT_EXTENSION.as_uri())};
+console.log(JSON.stringify({{
+  prompt: buildInitPrompt("/tmp/example-repo", "focus on release commands"),
+}}));
+'''
+        result = subprocess.run(
+            ["bun", "run", "-"],
+            cwd=REPO,
+            input=script,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise AssertionError(f"TypeScript execution failed:\n{result.stderr}")
+        prompt = json.loads(result.stdout)["prompt"]
+        self.assertIn("/tmp/example-repo", prompt)
+        self.assertIn("focus on release commands", prompt)
+        self.assertIn("all existing AGENTS.md", prompt)
+        self.assertIn("do not add parent-file references", prompt)
+        self.assertIn("@fradser/pi-kit", prompt)
+
+    def test_package_manifest_loads_extensions_directory(self) -> None:
+        manifest = json.loads((UTILS_PKG_DIR / "package.json").read_text(encoding="utf-8"))
+        self.assertIn("./extensions", manifest["pi"]["extensions"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/vision/README.md
+++ b/packages/vision/README.md
@@ -1,4 +1,4 @@
-# @fradser/pi-vision
+# pi-vision-fradser
 
 A transparent image-to-text bridge for Pi sessions whose active model cannot read images.
 
@@ -53,10 +53,10 @@ pi install /path/to/pi-packages/packages/vision
 When a version is available on npm, it can be installed with:
 
 ```bash
-pi install npm:@fradser/pi-vision
+pi install npm:pi-vision-fradser
 ```
 
-Check availability with `npm view @fradser/pi-vision version` before relying on the npm command.
+Check availability with `npm view pi-vision-fradser version` before relying on the npm command.
 
 ## Configure a vision model
 

--- a/packages/vision/package.json
+++ b/packages/vision/package.json
@@ -31,5 +31,8 @@
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*"
+  },
+  "dependencies": {
+    "@fradser/pi-kit": "workspace:*"
   }
 }

--- a/packages/vision/src/bridge.ts
+++ b/packages/vision/src/bridge.ts
@@ -1,5 +1,6 @@
-import type { Api, AssistantMessage, ImageContent, Model, TextContent, ThinkingContent, UserMessage } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, ImageContent, Model, ThinkingContent, UserMessage } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { extractTextContent } from "@fradser/pi-kit";
 
 const VISION_SYSTEM_PROMPT = [
   "You are a vision-to-text bridge for a coding assistant.",
@@ -14,11 +15,7 @@ export interface VisionBridgeResult {
 }
 
 function textFromResponse(message: AssistantMessage): string {
-  const text = message.content
-    .filter((part): part is TextContent => part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text)
-    .join("\n")
-    .trim();
+  const text = extractTextContent(message.content).trim();
   if (text) return text;
 
   const thinking = message.content

--- a/packages/vision/src/config.ts
+++ b/packages/vision/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { nonEmpty, parseModelRef } from "@fradser/pi-kit";
 
 export interface VisionConfig {
   provider?: string;
@@ -9,26 +10,6 @@ export interface VisionConfig {
 }
 
 const CONFIG_PATH = join(getAgentDir(), "vision.json");
-
-function nonEmpty(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-export function parseModelRef(value: string | undefined): { provider: string; model: string } | undefined {
-  const ref = nonEmpty(value);
-  if (!ref) return undefined;
-  const separator = ref.indexOf("/");
-  if (separator <= 0 || separator === ref.length - 1) return undefined;
-  return {
-    provider: ref.slice(0, separator),
-    model: ref.slice(separator + 1),
-  };
-}
-
-export function modelRef(config: VisionConfig): string | undefined {
-  if (config.provider && config.model) return `${config.provider}/${config.model}`;
-  return config.model;
-}
 
 export function readVisionConfig(): VisionConfig {
   let file: Partial<VisionConfig> = {};

--- a/packages/vision/src/index.ts
+++ b/packages/vision/src/index.ts
@@ -7,11 +7,19 @@ import type {
   ExtensionContext,
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
+import {
+  enterModelFromInput,
+  modelLabel,
+  modelRef,
+  parseModelRef,
+  PI_SPINNER_FRAMES,
+  PI_SPINNER_INTERVAL_MS,
+  selectModelFromMenu,
+  sortModels,
+} from "@fradser/pi-kit";
 import { buildImageAnalysisContext, describeImages } from "./bridge";
 import { extractInputImages, mayContainInputImage } from "./input-images";
 import {
-  modelRef,
-  parseModelRef,
   readVisionConfig,
   visionConfigPath,
   writeVisionConfig,
@@ -19,7 +27,6 @@ import {
 } from "./config";
 
 let config: VisionConfig = readVisionConfig();
-const VISION_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 type ContextTransform = { messages: ContextEvent["messages"] };
 
@@ -74,24 +81,15 @@ function configuredModelLabel(): string {
   return modelRef(config) ?? "(not configured)";
 }
 
-function modelLabel(model: Model<Api>): string {
-  return `${model.provider}/${model.id}`;
-}
-
-function modelOptionLabel(model: Model<Api>): string {
-  const current = modelLabel(model) === configuredModelLabel() ? " · current" : "";
-  return `${modelLabel(model)} · ${model.name}${current}`;
-}
-
 function imageModels(ctx: ExtensionContext): Model<Api>[] {
   const currentPiModels =
     ctx.scopedModels.length > 0
       ? ctx.scopedModels.map((scoped) => scoped.model)
       : ctx.modelRegistry.getAvailable();
 
-  return currentPiModels
-    .filter((model) => model.input.includes("image"))
-    .sort((left, right) => modelLabel(left).localeCompare(modelLabel(right)));
+  return sortModels(
+    currentPiModels.filter((model) => model.input.includes("image")),
+  );
 }
 
 function configSummary(ctx?: ExtensionContext): string {
@@ -157,39 +155,38 @@ async function chooseVisionModel(ctx: ExtensionCommandContext): Promise<void> {
     return;
   }
 
-  const options = models.map(modelOptionLabel);
-  const selected = await ctx.ui.select("Select a vision model", options);
-  if (!selected) return;
+  const result = await selectModelFromMenu(
+    ctx.ui,
+    models,
+    modelRef(config),
+    "Select a vision model",
+  );
+  if (!result) return;
 
-  const model = models[options.indexOf(selected)];
-  if (!model) return;
-
-  saveConfig({ ...config, provider: model.provider, model: model.id }, ctx);
-  ctx.ui.notify(`Vision reader set to ${modelLabel(model)}`, "info");
+  saveConfig({ ...config, ...result }, ctx);
+  ctx.ui.notify(`Vision reader set to ${result.provider}/${result.model}`, "info");
 }
 
 async function enterVisionModel(ctx: ExtensionCommandContext): Promise<void> {
-  const value = await ctx.ui.input("Vision model", configuredModelLabel() === "(not configured)" ? "provider/model" : configuredModelLabel());
-  if (value === undefined) return;
+  const result = await enterModelFromInput(
+    ctx.ui,
+    ctx.modelRegistry,
+    modelRef(config),
+    { label: "Vision model" },
+  );
+  if (!result) return;
 
-  const ref = parseModelRef(value);
-  if (!ref) {
-    ctx.ui.notify("Enter a model in provider/model format", "error");
+  const model = ctx.modelRegistry.find(result.provider, result.model);
+  if (!model?.input.includes("image")) {
+    ctx.ui.notify(
+      `Model ${result.provider}/${result.model} does not declare image input support`,
+      "error",
+    );
     return;
   }
 
-  const model = ctx.modelRegistry.find(ref.provider, ref.model);
-  if (!model) {
-    ctx.ui.notify(`Model ${ref.provider}/${ref.model} was not found in the model registry`, "error");
-    return;
-  }
-  if (!model.input.includes("image")) {
-    ctx.ui.notify(`Model ${ref.provider}/${ref.model} does not declare image input support`, "error");
-    return;
-  }
-
-  saveConfig({ ...config, ...ref }, ctx);
-  ctx.ui.notify(`Vision reader set to ${modelLabel(model)}`, "info");
+  saveConfig({ ...config, ...result }, ctx);
+  ctx.ui.notify(`Vision reader set to ${result.provider}/${result.model}`, "info");
 }
 
 async function resetConfiguration(ctx: ExtensionCommandContext): Promise<void> {
@@ -271,7 +268,7 @@ export default function visionExtension(pi: ExtensionAPI): void {
 
       try {
         ctx.ui.setStatus("vision", `reading ${images.length} image${images.length === 1 ? "" : "s"} · ${config.provider}/${config.model}`);
-        ctx.ui.setWorkingIndicator({ frames: VISION_SPINNER_FRAMES, intervalMs: 120 });
+        ctx.ui.setWorkingIndicator({ frames: PI_SPINNER_FRAMES, intervalMs: PI_SPINNER_INTERVAL_MS });
         const result = await describeImages(ctx.modelRegistry, visionModel, extracted.text, images, ctx.signal);
         const analysis = { analysisPrompt: extracted.text, analysis: result.text };
         if (activeAnalysis?.key === key) activeAnalysis.result = analysis;
@@ -350,7 +347,7 @@ export default function visionExtension(pi: ExtensionAPI): void {
         "vision",
         `reading ${images.length} image${images.length === 1 ? "" : "s"} · ${config.provider}/${config.model}`,
       );
-      ctx.ui.setWorkingIndicator({ frames: VISION_SPINNER_FRAMES, intervalMs: 120 });
+      ctx.ui.setWorkingIndicator({ frames: PI_SPINNER_FRAMES, intervalMs: PI_SPINNER_INTERVAL_MS });
 
       const prompt = toolAnalysisPrompt(event.toolName, event.input ?? {});
       const result = await describeImages(ctx.modelRegistry, visionModel, prompt, images, ctx.signal);

--- a/packages/vision/tests/test_vision_package.py
+++ b/packages/vision/tests/test_vision_package.py
@@ -168,7 +168,7 @@ def test_extension_registers_image_bridge_and_configuration_command() -> None:
     assert "describeImages" in (SRC / "bridge.ts").read_text(encoding="utf-8")
     assert 'action: "transform"' in source
     assert 'ctx.ui.select' in source
-    assert 'ctx.ui.input' in source
+    assert "enterModelFromInput" in source
     assert 'ctx.ui.confirm' in source
 
 
@@ -227,8 +227,10 @@ def test_bridge_only_handles_images_for_text_only_models() -> None:
     assert 'vision · not configured' not in source
     assert 'ctx.ui.setStatus("vision", undefined)' in source
     assert '`${config.enabled ? "vision"' not in source
-    assert 'const VISION_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]' in source
-    assert 'setWorkingIndicator({ frames: VISION_SPINNER_FRAMES, intervalMs: 120 })' in source
+    assert 'from "@fradser/pi-kit"' in source
+    assert "PI_SPINNER_FRAMES" in source
+    assert "PI_SPINNER_INTERVAL_MS" in source
+    assert "setWorkingIndicator({ frames: PI_SPINNER_FRAMES, intervalMs: PI_SPINNER_INTERVAL_MS })" in source
     assert 'frames: ["◐", "◓", "◑", "◒"]' not in source
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.84.1
+      '@fradser/pi-kit':
+        specifier: workspace:*
+        version: link:../pi-kit
       typebox:
         specifier: '*'
         version: 1.3.12
@@ -50,8 +53,23 @@ importers:
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.84.1
+      '@fradser/pi-kit':
+        specifier: workspace:*
+        version: link:../pi-kit
 
   packages/code-context:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: '*'
+        version: 0.84.1(ws@8.21.3)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: '*'
+        version: 0.84.1(ws@8.21.3)(zod@4.4.3)
+      typebox:
+        specifier: '*'
+        version: 1.3.12
+
+  packages/context:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: '*'
@@ -79,6 +97,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: '*'
         version: 0.84.1(ws@8.21.3)(zod@4.4.3)
+      '@fradser/pi-kit':
+        specifier: workspace:*
+        version: link:../pi-kit
 
   packages/monitor:
     dependencies:
@@ -92,6 +113,8 @@ importers:
         specifier: '*'
         version: 1.3.12
 
+  packages/pi-kit: {}
+
   packages/recap:
     dependencies:
       '@earendil-works/pi-coding-agent':
@@ -100,6 +123,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.84.1
+      '@fradser/pi-kit':
+        specifier: workspace:*
+        version: link:../pi-kit
 
   packages/utils:
     dependencies:
@@ -109,6 +135,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: '*'
         version: 0.84.1
+      '@fradser/pi-kit':
+        specifier: workspace:*
+        version: link:../pi-kit
 
   packages/vision:
     dependencies:
@@ -118,6 +147,9 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: '*'
         version: 0.84.1(ws@8.21.3)(zod@4.4.3)
+      '@fradser/pi-kit':
+        specifier: workspace:*
+        version: link:../pi-kit
 
 packages:
 

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -3,6 +3,8 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const packages = [
+  // pi-kit publishes first: consumer packages depend on it.
+  "@fradser/pi-kit",
   "@fradser/pi-memory",
   "@fradser/pi-btw",
   "@fradser/pi-monitor",


### PR DESCRIPTION
## What
Introduce `@fradser/pi-kit` as the shared internal runtime package and rewire the six published consumer packages (agent-teams, btw, memory, recap, utils, vision) to import from it, plus a packaging/loading fix for pi-memory and a monitor key-handling fix.

## Why
- Remove duplicated TUI/message/model-selection helpers that were copy-pasted across packages (spinner frames, theme style callbacks, message text extraction, model-selection menu).
- Fix `@fradser/pi-memory`: its published 0.2.3 tarball was missing `config.ts` (it sat outside the shipped files/extensions dir yet `inject-memory.ts` imported `../config`), and the extension loader globbed the dir (no `index.ts`) so `config.ts` was loaded as an extension entry and crashed. Both fixed.
- pi-kit is a normal npm `dependencies` entry (`workspace:*` rewrites to `0.1.0` on pack), so a user installing any consumer gets pi-kit automatically — they never install it themselves. `@fradser/pi-kit@0.1.0` is already published and npm-trust configured.

## Changes
- `packages/pi-kit` (new): `PI_SPINNER_FRAMES`/`PI_SPINNER_INTERVAL_MS`, `createPiThemeStyle`, `extractTextContent`, `parseModelRef`/`modelRef`/`modelLabel`/`sortModels`/`selectModelFromMenu`/`enterModelFromInput`.
- Consumers rewire to pi-kit; `BtwOverlayStyle` aliases `PiThemeStyle`.
- monitor: hand-rolled escape check to `matchesKey(data, Key.escape)`.
- memory: `config.ts` to `extensions/config.ts`, `pi.extensions` to the single factory file, import `./config`.
- `publish-release.mjs`: pi-kit listed first; patch changeset for the seven consumers.

## Review cycle
0 comments triaged; no reviewer comments were posted. The `Code Terrier Review` external check failed with "Review failed to complete" (external-service infrastructure failure, zero findings, non-required, not re-triggerable in-band).
Full breakdown: https://github.com/FradSer/pi-packages/pull/9#issuecomment-5327418211

## Verification
- `npx tsc --noEmit` passes across all packages.
- `python3 -m pytest packages`: 249 passed; the only 2 failures (agent-teams/mattpocock manifest-name assertions expecting legacy `-fradser` names) are pre-existing on main and unrelated.
- `pnpm pack` shows `workspace:*` -> `0.1.0` and that `extensions/config.ts` ships; every consumer tarball carries `@fradser/pi-kit: 0.1.0`.
- `@fradser/pi-kit@0.1.0` published (200) with npm-trust configured; `pnpm changeset status` confirms the 7 patch bumps.
