### PR TITLE
feat(packages): resolve tool allowlist at spawn

### DIFF
--- a/.changeset/agent-teams-tool-grant-visibility.md
+++ b/.changeset/agent-teams-tool-grant-visibility.md
@@ -1,0 +1,5 @@
+---
+"@fradser/pi-agent-teams": minor
+---
+
+Spawn surfaces now expose each teammate's effective tool allowlist: `teammate_spawn` records the granted tools in the roster before the first wake, the spawn result line and console detail name them, and a role derived inline without a `tools` field visibly shows its narrow capability-only grant. Leader guidance now requires matching definition tools to the assignment — file-inspecting work needs explicit `read`/`bash` — and prescribes shutdown-plus-respawn instead of steering when capabilities are missing. This prevents workers from burning turns discovering they cannot execute their kickoff.

--- a/packages/agent-teams/features/agent-teams.feature
+++ b/packages/agent-teams/features/agent-teams.feature
@@ -397,6 +397,12 @@ Feature: Agent Teams collaborative organization contract
       And a respawn composes context from the original kickoff, mailbox reports, board claims, and the console detail transcript
       And the harness never reclaims, restarts, or replaces a teammate on its own
 
+    Scenario: The leader guidance requires explicit worker tooling
+      Given the leader derives an inline role for file-inspecting work
+      When before_agent_start builds the leader guidance
+      Then it warns that a definition without tools grants only the capability set
+      And it instructs respawning with read and bash when a teammate reports missing capabilities instead of steering it
+
   Rule: Leader tool surface is exact
 
     Scenario: Spawning renders one started line per teammate
@@ -412,6 +418,13 @@ Feature: Agent Teams collaborative organization contract
       Given the leader spawns a teammate with a long name and kickoff prompt
       When the started row renders in a narrow transcript
       Then the row stays on one line and does not exceed the available width
+
+    Scenario: The roster and spawn render expose the effective tool allowlist
+      Given the leader spawns a teammate from a role definition with tools
+      Then the roster records the exact tool allowlist granted to the child process
+      And the spawn result names the granted tools before the teammate's first wake
+      And a role derived inline without a tools field shows only the capability set
+      And missing read or bash for a file-inspecting assignment is visible at spawn time, not after wasted worker turns
 
     Scenario: Shutting down renders one collapsible agent event line
       Given the leader shuts down a teammate

--- a/packages/agent-teams/src/guidance.ts
+++ b/packages/agent-teams/src/guidance.ts
@@ -82,6 +82,13 @@ inbox messages and claimable board tasks, and can message peers directly.
 A session-wide cap of 8 living teammates applies. An agent with
 worktree: true receives its own git worktree; its diff is captured at shutdown.
 
+Match the definition's \`tools\` to the assignment. A role without a \`tools\`
+field grants only the capability set (send_message, task_list, task_claim,
+task_submit): any work that must read files or run commands needs \`read\` and
+\`bash\` listed explicitly. The spawn result names the granted list — if a
+teamate reports missing capabilities or the kickoff demands tools it lacks,
+teammate_shutdown it and respawn with the right tools instead of steering.
+
 Users may also ask for these conversationally ("add a reviewer teammate",
 "create a scribe role") — apply the same create-on-demand step above when
 the role does not exist yet. The human-facing management surface is the

--- a/packages/agent-teams/src/spawner.ts
+++ b/packages/agent-teams/src/spawner.ts
@@ -53,6 +53,23 @@ export function isCleanExit(result: Pick<WorkerProcessResult, "exitCode" | "sign
   return result.exitCode === 0 && result.signal === null;
 }
 
+/** Tools every teammate receives regardless of its role definition. */
+export const WORKER_CAPABILITY_TOOLS: readonly string[] = [
+  "send_message",
+  "task_list",
+  "task_claim",
+  "task_submit",
+];
+
+/** Effective tool allowlist for one teammate: the role's requested tools plus
+ *  the capability set, deduplicated in request order. Roles without a tools
+ *  field get exactly the capability set — leaders should see that narrow
+ *  grant before the first wake so missing read/bash is obvious at spawn time. */
+export function resolveWorkerTools(requested?: string[]): string[] {
+  const requestedOnly = (requested ?? []).filter((tool) => !WORKER_CAPABILITY_TOOLS.includes(tool));
+  return [...new Set([...requestedOnly, ...WORKER_CAPABILITY_TOOLS])];
+}
+
 // ── Process registry ──────────────────────────────────────────────
 
 /** Live children by teammate name — powers steering, prompting, and shutdown. */
@@ -333,9 +350,7 @@ export function spawnResident(options: ResidentSpawnOptions): SpawnedResident | 
     "--extension", WORKER_EXTENSION,
   ];
   if (options.model) args.push("--model", options.model);
-  const capabilityTools = ["send_message", "task_list", "task_claim", "task_submit"];
-  const requestedTools = (options.tools ?? []).filter((tool) => !capabilityTools.includes(tool));
-  args.push("--tools", [...new Set([...requestedTools, ...capabilityTools])].join(","));
+  args.push("--tools", resolveWorkerTools(options.tools).join(","));
 
   let tempDir: string | undefined;
   const cleanupTempDir = () => {

--- a/packages/agent-teams/src/statefile.ts
+++ b/packages/agent-teams/src/statefile.ts
@@ -79,13 +79,13 @@ export function appendInboxMessage(file: string, message: { id: string; from: st
 }
 
 /** Publish the worker-readable roster of living teammates. */
-export function writeRoster(file: string, teammates: Array<{ name: string; agent: string; status: string }>): void {
+export function writeRoster(file: string, teammates: Array<{ name: string; agent: string; status: string; tools?: string[] }>): void {
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
   writeJsonAtomic(file, { teammates });
 }
 
 /** Read the roster from inside a teammate process; unknown roster = empty. */
-export function readRoster(file: string): Array<{ name: string; agent: string; status: string }> {
+export function readRoster(file: string): Array<{ name: string; agent: string; status: string; tools?: string[] }> {
   try {
     const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as { teammates?: Array<{ name: string; agent: string; status: string }> };
     return Array.isArray(parsed.teammates) ? parsed.teammates : [];

--- a/packages/agent-teams/src/team-machine.ts
+++ b/packages/agent-teams/src/team-machine.ts
@@ -303,7 +303,7 @@ function flushSnapshots(): void {
   const stateFile = requireStateFile();
   try {
     writeStateFile(stateFile, getState());
-    writeRoster(rosterPath(stateFile), livingTeammates().map((t) => ({ name: t.name, agent: t.agent, status: t.status })));
+    writeRoster(rosterPath(stateFile), livingTeammates().map((t) => ({ name: t.name, agent: t.agent, status: t.status, tools: t.tools })));
     if (boardFile) writeBoardFile(boardFile, getState().tasks);
     clearStateDirty();
   } catch {

--- a/packages/agent-teams/src/team-machine.ts
+++ b/packages/agent-teams/src/team-machine.ts
@@ -63,6 +63,7 @@ import { isWorkerEvent } from "./types.ts";
 import {
   deliverPrompt,
   isCleanExit,
+  resolveWorkerTools,
   sendWorkerSteer,
   spawnResident,
   terminateAllTeammates,
@@ -398,7 +399,9 @@ export function spawnTeammate(input: {
   }
 
   const spawnModel = resolveSpawnModel(agent.model, getTeamDefaultModel(), leaderModelRef());
-  updateTeammate(input.name, { model: spawnModel.model });
+  // Record the grant before the first wake: a role derived without tools shows
+  // its narrow capability-only allowlist right on the spawn surface.
+  updateTeammate(input.name, { model: spawnModel.model, tools: resolveWorkerTools(agent.tools) });
 
   const started = spawnResident({
     workerName: input.name,

--- a/packages/agent-teams/src/tools.ts
+++ b/packages/agent-teams/src/tools.ts
@@ -40,7 +40,8 @@ export function registerLeaderTools(pi: ExtensionAPI): void {
         return new Text(theme.fg("error", text.split("\n")[0] || "Failed to spawn teammate."), 0, 0);
       }
       const params = context.args as { name: string; prompt?: string };
-      const tools = getTeammate(params.name)?.tools;
+      const details = result.details as { started?: boolean; tools?: string[] } | undefined;
+      const tools = details?.tools ?? getTeammate(params.name)?.tools;
       const toolsNote = tools?.length ? `${theme.fg("dim", " · ")}${theme.fg("muted", `tools: ${tools.join(", ")}`)}` : "";
       const line = `${theme.fg("toolTitle", theme.bold(formatToolEventLabel("started", "", "agent").trimEnd()))} ${theme.fg("accent", `@${params.name}`)} ${theme.fg("dim", "·")} ${theme.fg("customMessageText", theme.bold(formatAgentTaskName(params.prompt ?? "", params.name)))}${toolsNote}`;
       return {
@@ -58,7 +59,7 @@ export function registerLeaderTools(pi: ExtensionAPI): void {
         : "It is idle: it wakes for inbox messages and claimable board tasks.";
       return {
         content: [{ type: "text", text: `@${params.name} is alive as ${params.agent} (tools: ${granted.join(", ")}).\n${kickoffNote}\n\n${rosterSummary()}` }],
-        details: { started: true },
+        details: { started: true, tools: granted },
       };
     },
   });

--- a/packages/agent-teams/src/tools.ts
+++ b/packages/agent-teams/src/tools.ts
@@ -10,7 +10,7 @@ import {
   shutdownTeammate,
   spawnTeammate,
 } from "./team-machine.ts";
-import { listTasks, livingTeammates } from "./state.ts";
+import { listTasks, livingTeammates, getTeammate } from "./state.ts";
 import { LEADER_RECIPIENT, SendMessageParams, TeammateShutdownParams, TeammateSpawnParams, TaskCreateParams } from "./types.ts";
 import { registerTaskListTool } from "./worker.ts";
 import { openTeamConsole, refreshTeamUI } from "./ui.ts";
@@ -39,8 +39,10 @@ export function registerLeaderTools(pi: ExtensionAPI): void {
       if (context.isError) {
         return new Text(theme.fg("error", text.split("\n")[0] || "Failed to spawn teammate."), 0, 0);
       }
-      const params = context.args as { name: string; agent: string; prompt?: string };
-      const line = `${theme.fg("toolTitle", theme.bold(formatToolEventLabel("started", "", "agent").trimEnd()))} ${theme.fg("accent", `@${params.name}`)} ${theme.fg("dim", "·")} ${theme.fg("customMessageText", theme.bold(formatAgentTaskName(params.prompt ?? "", params.name)))}`;
+      const params = context.args as { name: string; prompt?: string };
+      const tools = getTeammate(params.name)?.tools;
+      const toolsNote = tools?.length ? `${theme.fg("dim", " · ")}${theme.fg("muted", `tools: ${tools.join(", ")}`)}` : "";
+      const line = `${theme.fg("toolTitle", theme.bold(formatToolEventLabel("started", "", "agent").trimEnd()))} ${theme.fg("accent", `@${params.name}`)} ${theme.fg("dim", "·")} ${theme.fg("customMessageText", theme.bold(formatAgentTaskName(params.prompt ?? "", params.name)))}${toolsNote}`;
       return {
         render: (width: number) => width > 0 ? [truncateToWidth(line, width)] : [],
         invalidate: () => {},
@@ -50,11 +52,12 @@ export function registerLeaderTools(pi: ExtensionAPI): void {
       const result = spawnTeammate(params);
       if (!result.ok) throw new Error(result.error);
       refreshTeamUI(ctx);
+      const granted = getTeammate(params.name)?.tools ?? [];
       const kickoffNote = params.prompt?.trim()
         ? "It received your kickoff prompt and is working on it."
         : "It is idle: it wakes for inbox messages and claimable board tasks.";
       return {
-        content: [{ type: "text", text: `@${params.name} is alive as ${params.agent}.\n${kickoffNote}\n\n${rosterSummary()}` }],
+        content: [{ type: "text", text: `@${params.name} is alive as ${params.agent} (tools: ${granted.join(", ")}).\n${kickoffNote}\n\n${rosterSummary()}` }],
         details: { started: true },
       };
     },

--- a/packages/agent-teams/src/types.ts
+++ b/packages/agent-teams/src/types.ts
@@ -48,6 +48,9 @@ export interface Teammate {
   noticedTaskIds?: string[];
   usage?: WorkerUsage;
   error?: string;
+  /** Effective tool allowlist granted to the child process (role tools plus
+   *  the capability set). Absent only for legacy snapshots. */
+  tools?: string[];
   createdAt: number;
   updatedAt: number;
   stoppedAt?: number;

--- a/packages/agent-teams/src/ui.ts
+++ b/packages/agent-teams/src/ui.ts
@@ -203,6 +203,7 @@ function buildTeammateDetail(name: string): string[] {
     `  Status: ${teammate.status}${teammate.currentTaskId ? ` | Task: ${teammate.currentTaskId}` : ""}`,
     `  Spawn: ${teammate.pid > 0 ? `pid ${teammate.pid}` : "pid unknown"} | Isolation: ${teammate.isolation}`,
     ...(teammate.model ? [`  Launch model: ${teammate.model}`] : []),
+    ...(teammate.tools?.length ? [`  Tools: ${teammate.tools.join(", ")}`] : []),
     `  Created: ${new Date(teammate.createdAt).toLocaleString()}`,
   ];
   if (teammate.stoppedAt) lines.push(`  Stopped: ${new Date(teammate.stoppedAt).toLocaleString()}`);

--- a/packages/agent-teams/tests/test_teammate_package.py
+++ b/packages/agent-teams/tests/test_teammate_package.py
@@ -1774,6 +1774,51 @@ def test_silent_stall_independent_of_notice_pace() -> None:
     assert payload["tier"] == 300_000
 
 
+def test_worker_tool_grant_is_visible_at_spawn() -> None:
+    feature = (PACKAGE / "features" / "agent-teams.feature").read_text(encoding="utf-8")
+    spawner = source("spawner.ts")
+    machine = source("team-machine.ts")
+    guidance = source("guidance.ts")
+    types = source("types.ts")
+    ui = source("ui.ts")
+    tools_src = source("tools.ts")
+    for phrase in (
+        "The roster and spawn render expose the effective tool allowlist",
+        "The leader guidance requires explicit worker tooling",
+        "a role derived inline without a tools field shows only the capability set",
+    ):
+        assert phrase in feature, phrase
+    assert "resolveWorkerTools" in spawner and "WORKER_CAPABILITY_TOOLS" in spawner
+    assert 'args.push("--tools", resolveWorkerTools(options.tools).join(","))' in spawner
+    # The roster records the grant before the first wake.
+    assert "tools: resolveWorkerTools(agent.tools)" in machine
+    assert "tools?: string[]" in types
+    # Spawn surfaces name the granted list so missing read/bash is obvious immediately.
+    assert "granted.join(\", \")" in tools_src
+    assert "Tools: ${teammate.tools.join(", ")}" in ui
+    for phrase in (
+        "grants only the capability set",
+        "respawn with the right tools instead of steering",
+    ):
+        assert phrase in guidance, phrase
+    payload = run_node(
+        f'''\
+        import {{ resolveWorkerTools }} from "{(SRC / "spawner.ts").as_uri()}";
+        console.log(JSON.stringify({{
+          capabilityOnly: resolveWorkerTools(undefined),
+          emptyRole: resolveWorkerTools([]),
+          withShell: resolveWorkerTools(["read", "bash", "send_message"]),
+          dedupesCapability: resolveWorkerTools(["task_list"]),
+        }}));
+        '''
+    )
+    capability = ["send_message", "task_list", "task_claim", "task_submit"]
+    assert payload["capabilityOnly"] == capability
+    assert payload["emptyRole"] == capability
+    assert payload["withShell"] == ["read", "bash"] + capability
+    assert payload["dedupesCapability"] == capability
+
+
 def test_stall_recovery_belongs_to_leader_alone() -> None:
     machine = source("team-machine.ts")
     tools = source("tools.ts")

--- a/packages/agent-teams/tests/test_teammate_package.py
+++ b/packages/agent-teams/tests/test_teammate_package.py
@@ -1252,7 +1252,7 @@ def test_spawn_renders_legacy_started_line() -> None:
     assert "Spawning renders one started line per teammate" in feature
     assert 'formatToolEventLabel("started", "", "agent")' in tools
     assert "formatAgentTaskName" in tools
-    assert "details: { started: true }" in tools
+    assert "details: { started: true, tools: granted }" in tools
 
 
 def test_spawn_started_line_fits_narrow_tui_width() -> None:

--- a/packages/agent-teams/tests/test_teammate_package.py
+++ b/packages/agent-teams/tests/test_teammate_package.py
@@ -1790,9 +1790,14 @@ def test_worker_tool_grant_is_visible_at_spawn() -> None:
         assert phrase in feature, phrase
     assert "resolveWorkerTools" in spawner and "WORKER_CAPABILITY_TOOLS" in spawner
     assert 'args.push("--tools", resolveWorkerTools(options.tools).join(","))' in spawner
-    # The roster records the grant before the first wake.
+    # The roster records the grant before the first wake — both leader state
+    # and the worker-readable roster snapshot.
     assert "tools: resolveWorkerTools(agent.tools)" in machine
+    assert "status: t.status, tools: t.tools" in machine
     assert "tools?: string[]" in types
+    # Persisted in result details so historical renders survive session restarts.
+    assert "details: { started: true, tools: granted }" in tools_src
+    assert "details?.tools ?? getTeammate(params.name)?.tools" in tools_src
     # Spawn surfaces name the granted list so missing read/bash is obvious immediately.
     assert "granted.join(\", \")" in tools_src
     assert "Tools: ${teammate.tools.join(", ")}" in ui


### PR DESCRIPTION
## What
Teammates now expose their effective tool allowlist from the moment of spawn: roster state, spawn result, started render, and console detail all name exactly what the child process was granted, and leader guidance teaches how to size `tools` to the assignment.

## Why
Three times in one day, teammates spawned from inline definitions without a `tools` field woke with only the coordination capability set, burned turns discovering they could not read files or run commands, and reported incapability only after the leader paid for dead turns. The grant was invisible at spawn time.

## Changes
- `resolveWorkerTools` (spawner.ts) is the single source of the effective allowlist; team-machine persists it on the roster before the first wake, including the worker-readable snapshot.
- Spawn result text, started render (persisted in tool-result details so re-renders survive restarts), and `/agent-teams` detail view all show the granted tools.
- Guidance: definitions without `tools` grant only send_message/task_list/task_claim/task_submit; file-inspecting work needs explicit `read`/`bash`; missing capabilities mean shutdown plus respawn, not steering.
- BDD scenarios + behavioral tests; changeset for @fradser/pi-agent-teams minor.

## Review cycle
2 findings triaged over 1 baseline round, 2 adopted, 1 external bot notice rejected; all project checks green.
Full breakdown: https://github.com/FradSer/pi-packages/pull/18#issuecomment-5404126162

## Verification
- `python3 -m pytest packages/agent-teams/tests/` — 72 passed
- `pnpm test` — 378 passed across monorepo
- `npx tsc --noEmit -p tsconfig.extensions.json` — clean
- Independent one-shot baseline review + triage of the diff: 2 findings adopted, fixes verified by fresh review passes
