### PR TITLE
fix(packages): teammate status truth and stall classifier

### DIFF
--- a/.changeset/agent-teams-status-truth-and-classifier.md
+++ b/.changeset/agent-teams-status-truth-and-classifier.md
@@ -1,0 +1,5 @@
+---
+"@fradser/pi-agent-teams": minor
+---
+
+Fixes from the first live analysis of the stall watchdog and tool-grant work, plus the delivery-gap root cause it surfaced: a spawned teammate runs its kickoff turn immediately, so marking prompt-less spawns idle at birth mislabeled an actively-running turn as idle — queued leader messages were then delivered into that running turn and lost (the teammate kept reporting "board empty" until a steer landed). Status now stays "starting" until real stream events arrive and flows starting→working→idle from stream truth. The provider-hang classifier now keys on recognized stream activity (text/thinking/toolcall/tool events) instead of usage totals — providers that omit usage after real output are no longer misclassified, and an empty message_end artifact never counts; usage stays diagnostics. The grant is flushed to both rosters before the kickoff is written, and historical spawn renders read persisted details only so name reuse cannot display another incarnation's allowlist.

--- a/packages/agent-teams/features/agent-teams.feature
+++ b/packages/agent-teams/features/agent-teams.feature
@@ -181,10 +181,16 @@ Feature: Agent Teams collaborative organization contract
       And a later silent episode can raise a fresh notice
 
     Scenario: A provider hang is flagged before the default stall window
-      Given a working teammate has received no model output yet and runs no tool
+      Given a working teammate has received no recognized stream activity and runs no tool
       When its silence passes the silent-stall interval while staying under the default stall-notice interval
-      Then the leader receives one stall notice reporting zero lifetime model output
+      Then the leader receives one stall notice reporting zero model output
       And the notice names shutdown plus respawn as the effective remedy instead of steering
+
+    Scenario: Recognized stream activity counts as output regardless of usage totals
+      Given a working teammate whose stream delivered text, thinking, or tool events without usage totals
+      When its silence grows past the silent-stall interval
+      Then the general stall window governs instead of the provider-hang tier
+      And an empty message_end artifact alone never counts as model output
 
     Scenario: Stall notices carry lifetime usage diagnostics
       Given a silent working teammate with recorded lifetime token usage

--- a/packages/agent-teams/src/guidance.ts
+++ b/packages/agent-teams/src/guidance.ts
@@ -86,7 +86,7 @@ Match the definition's \`tools\` to the assignment. A role without a \`tools\`
 field grants only the capability set (send_message, task_list, task_claim,
 task_submit): any work that must read files or run commands needs \`read\` and
 \`bash\` listed explicitly. The spawn result names the granted list — if a
-teamate reports missing capabilities or the kickoff demands tools it lacks,
+teammate reports missing capabilities or the kickoff demands tools it lacks,
 teammate_shutdown it and respawn with the right tools instead of steering.
 
 Users may also ask for these conversationally ("add a reviewer teammate",

--- a/packages/agent-teams/src/spawner.ts
+++ b/packages/agent-teams/src/spawner.ts
@@ -263,10 +263,10 @@ function applyStreamLine(state: StreamState, line: string): boolean {
     if (event.message.stopReason === "stop") state.finalResponse = true;
     const parts = extractTextContent(event.message.content, "");
     if (parts.trim()) state.text = parts;
+    // Usage stays diagnostics: only streamed content counts as model output,
+    // so input-only or failed responses cannot bypass the zero-output tier.
     const u = event.message.usage;
-    // A bare empty message_end (RPC startup artifact) must not count as model
-    // output; real content or usage does.
-    if (parts.trim() || (u && (u.totalTokens ?? 0) > 0)) state.modelOutputSeen = true;
+    if (parts.trim()) state.modelOutputSeen = true;
     if (u) {
       state.usage = {
         input: (state.usage?.input ?? 0) + (u.input ?? 0),

--- a/packages/agent-teams/src/spawner.ts
+++ b/packages/agent-teams/src/spawner.ts
@@ -44,6 +44,10 @@ export interface WorkerProgressUpdate {
   turns: number;
   /** True after the current sequence's final response. */
   finalResponse?: boolean;
+  /** True once the stream delivered recognized model activity (text, thinking,
+   *  tool-call, or tool execution events). Independent of usage totals so
+   *  providers that omit usage are not misclassified as silent. */
+  modelOutputSeen?: boolean;
   /** Lifetime accumulated usage parsed from message_end events. */
   usage?: WorkerUsage;
 }
@@ -183,6 +187,9 @@ interface StreamState {
   /** Lifetime count of completed assistant messages. */
   turns: number;
   finalResponse?: boolean;
+  /** Set by any recognized model/stream activity; never by a bare empty
+   *  message_end artifact. The stall classifier uses this, not usage. */
+  modelOutputSeen?: boolean;
   usage?: WorkerUsage;
 }
 
@@ -236,11 +243,13 @@ function applyStreamLine(state: StreamState, line: string): boolean {
     return false;
   }
   if (event.type === "tool_execution_start") {
+    state.modelOutputSeen = true;
     state.activeTools.set(event.toolCallId ?? `tool-${state.activeTools.size}`, toolExecutionLabel(event.toolName, event.args));
     state.activeTool = [...state.activeTools.values()].at(-1);
     return true;
   }
   if (event.type === "tool_execution_end") {
+    state.modelOutputSeen = true;
     if (event.toolCallId) state.activeTools.delete(event.toolCallId);
     else state.activeTools.clear();
     state.activeTool = [...state.activeTools.values()].at(-1);
@@ -255,6 +264,9 @@ function applyStreamLine(state: StreamState, line: string): boolean {
     const parts = extractTextContent(event.message.content, "");
     if (parts.trim()) state.text = parts;
     const u = event.message.usage;
+    // A bare empty message_end (RPC startup artifact) must not count as model
+    // output; real content or usage does.
+    if (parts.trim() || (u && (u.totalTokens ?? 0) > 0)) state.modelOutputSeen = true;
     if (u) {
       state.usage = {
         input: (state.usage?.input ?? 0) + (u.input ?? 0),
@@ -271,23 +283,28 @@ function applyStreamLine(state: StreamState, line: string): boolean {
   if (!sub) return false;
   switch (sub.type) {
     case "text_delta":
+      state.modelOutputSeen = true;
       state.activeTool = undefined;
       state.text += sub.delta ?? "";
       return true;
     case "thinking_delta":
+      state.modelOutputSeen = true;
       state.activeTool = undefined;
       state.thinking += sub.delta ?? "";
       return true;
     case "toolcall_start":
+      state.modelOutputSeen = true;
       clearActiveTools(state);
       return true;
     case "toolcall_delta": {
+      state.modelOutputSeen = true;
       state.toolcallArgs += sub.delta ?? "";
       const label = toolcallLabel(state.toolcallArgs);
       if (label) state.activeTool = label;
       return true;
     }
     case "toolcall_end":
+      state.modelOutputSeen = true;
       // Execution events own the activity label until the result arrives.
       clearActiveTools(state);
       return true;
@@ -395,6 +412,7 @@ export function spawnResident(options: ResidentSpawnOptions): SpawnedResident | 
     liveThinking: truncate(streamState.thinking, OUTPUT_CAP),
     turns: Math.max(0, streamState.turns - (baselines.get(options.workerName) ?? 0)),
     finalResponse: streamState.finalResponse,
+    modelOutputSeen: streamState.modelOutputSeen,
     usage: streamState.usage,
   });
 

--- a/packages/agent-teams/src/state.ts
+++ b/packages/agent-teams/src/state.ts
@@ -142,6 +142,7 @@ export function updateTeammateProgress(
   spawnId: string,
   progress: Pick<Teammate, "liveText" | "activeTool" | "liveThinking" | "turns"> & {
     sequenceEnded?: boolean;
+    modelOutputSeen?: boolean;
     usage?: WorkerUsage;
   },
 ): boolean {
@@ -152,6 +153,7 @@ export function updateTeammateProgress(
   teammate.liveThinking = progress.liveThinking;
   teammate.turns = progress.turns;
   if (progress.sequenceEnded !== undefined) teammate.sequenceEnded = progress.sequenceEnded;
+  if (progress.modelOutputSeen) teammate.modelOutputSeen = true;
   if (progress.usage) teammate.usage = progress.usage;
   if (teammate.status === "starting") {
     teammate.status = progress.sequenceEnded ? "idle" : "working";

--- a/packages/agent-teams/src/statefile.ts
+++ b/packages/agent-teams/src/statefile.ts
@@ -87,7 +87,7 @@ export function writeRoster(file: string, teammates: Array<{ name: string; agent
 /** Read the roster from inside a teammate process; unknown roster = empty. */
 export function readRoster(file: string): Array<{ name: string; agent: string; status: string; tools?: string[] }> {
   try {
-    const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as { teammates?: Array<{ name: string; agent: string; status: string }> };
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as { teammates?: Array<{ name: string; agent: string; status: string; tools?: string[] }> };
     return Array.isArray(parsed.teammates) ? parsed.teammates : [];
   } catch {
     return [];

--- a/packages/agent-teams/src/team-machine.ts
+++ b/packages/agent-teams/src/team-machine.ts
@@ -134,15 +134,18 @@ export function formatSilenceDuration(milliseconds: number): string {
   return `${minutes}m`;
 }
 
-/** True when the stream has delivered model output (usage totals) at least once. */
-export function hasModelOutput(teammate: Pick<Teammate, "usage">): boolean {
-  return !!teammate.usage && teammate.usage.totalTokens > 0;
+/** True when the stream has delivered recognized model activity (text,
+ * thinking, tool-call, or tool execution events) at least once — the stall
+ * classifier. Usage totals stay diagnostics only: providers may omit them
+ * after real output, and an empty message_end artifact must not count. */
+export function hasModelOutput(teammate: Pick<Teammate, "modelOutputSeen">): boolean {
+  return teammate.modelOutputSeen === true;
 }
 
 /** Silence threshold for one teammate. A worker that has never received model
  * output and runs no tool is almost certainly blocked on the provider rather
  * than doing slow work; that signature uses the shorter silent-stall window. */
-export function stallThresholdMs(teammate: Pick<Teammate, "usage" | "activeTool">): number {
+export function stallThresholdMs(teammate: Pick<Teammate, "modelOutputSeen" | "activeTool">): number {
   if (STALL_NOTICE_MS <= 0 || SILENT_STALL_MS <= 0) return STALL_NOTICE_MS;
   if (!hasModelOutput(teammate) && !teammate.activeTool) return SILENT_STALL_MS;
   return STALL_NOTICE_MS;
@@ -157,7 +160,7 @@ function usageLine(usage: WorkerUsage | undefined): string {
  * duration, spawn age, lifetime usage, and — for the zero-output provider-hang
  * signature — the remedy that actually works (shutdown + respawn). */
 export function stallNoticeBody(
-  teammate: Pick<Teammate, "name" | "createdAt" | "activeTool" | "usage">,
+  teammate: Pick<Teammate, "name" | "createdAt" | "activeTool" | "modelOutputSeen" | "usage">,
   silenceMs: number,
   now = Date.now(),
 ): string {
@@ -402,6 +405,9 @@ export function spawnTeammate(input: {
   // Record the grant before the first wake: a role derived without tools shows
   // its narrow capability-only allowlist right on the spawn surface.
   updateTeammate(input.name, { model: spawnModel.model, tools: resolveWorkerTools(agent.tools) });
+  // Flush before the kickoff is written: a fast child must not read a stale
+  // worker-readable roster missing its own entry or tool grant.
+  publishStateSnapshot();
 
   const started = spawnResident({
     workerName: input.name,
@@ -418,8 +424,10 @@ export function spawnTeammate(input: {
     return { ok: false, error: started.error };
   }
   updateTeammate(input.name, { pid: started.pid });
-  // A prompt-less spawn has no stream activity; it is idle from birth.
-  if (!input.prompt?.trim()) updateTeammate(input.name, { status: "idle" });
+  // Status stays "starting" until real stream events arrive: every spawned
+  // teammate runs a kickoff turn, so marking prompt-less spawns idle here used
+  // to mislabel an actively-running turn as idle and misroute deliveries
+  // (queued instead of steered, then lost inside the running turn).
   publishStateSnapshot();
   ensureLivePoll();
   notifyChange();
@@ -539,6 +547,7 @@ function applyProgress(name: string, spawnId: string, progress: {
   liveThinking?: string;
   turns: number;
   finalResponse?: boolean;
+  modelOutputSeen?: boolean;
   usage?: WorkerUsage;
 }): void {
   const teammate = getTeammate(name);
@@ -550,6 +559,7 @@ function applyProgress(name: string, spawnId: string, progress: {
     liveThinking: progress.liveThinking,
     turns: progress.turns,
     sequenceEnded: progress.finalResponse === true ? true : undefined,
+    modelOutputSeen: progress.modelOutputSeen,
     usage: progress.usage,
   });
   updateTeammate(name, { lastOutputAt: Date.now(), stallNoticeSentAt: undefined });

--- a/packages/agent-teams/src/tools.ts
+++ b/packages/agent-teams/src/tools.ts
@@ -41,7 +41,9 @@ export function registerLeaderTools(pi: ExtensionAPI): void {
       }
       const params = context.args as { name: string; prompt?: string };
       const details = result.details as { started?: boolean; tools?: string[] } | undefined;
-      const tools = details?.tools ?? getTeammate(params.name)?.tools;
+      // Details only: falling back to live roster state would mislabel history
+      // after a teammate name is reused with a different grant.
+      const tools = details?.tools;
       const toolsNote = tools?.length ? `${theme.fg("dim", " · ")}${theme.fg("muted", `tools: ${tools.join(", ")}`)}` : "";
       const line = `${theme.fg("toolTitle", theme.bold(formatToolEventLabel("started", "", "agent").trimEnd()))} ${theme.fg("accent", `@${params.name}`)} ${theme.fg("dim", "·")} ${theme.fg("customMessageText", theme.bold(formatAgentTaskName(params.prompt ?? "", params.name)))}${toolsNote}`;
       return {

--- a/packages/agent-teams/src/tools.ts
+++ b/packages/agent-teams/src/tools.ts
@@ -58,7 +58,7 @@ export function registerLeaderTools(pi: ExtensionAPI): void {
       const granted = getTeammate(params.name)?.tools ?? [];
       const kickoffNote = params.prompt?.trim()
         ? "It received your kickoff prompt and is working on it."
-        : "It is idle: it wakes for inbox messages and claimable board tasks.";
+        : "It received the standard board-check kickoff and is running its first turn; it idles once that settles.";
       return {
         content: [{ type: "text", text: `@${params.name} is alive as ${params.agent} (tools: ${granted.join(", ")}).\n${kickoffNote}\n\n${rosterSummary()}` }],
         details: { started: true, tools: granted },

--- a/packages/agent-teams/src/types.ts
+++ b/packages/agent-teams/src/types.ts
@@ -51,6 +51,9 @@ export interface Teammate {
   /** Effective tool allowlist granted to the child process (role tools plus
    *  the capability set). Absent only for legacy snapshots. */
   tools?: string[];
+  /** True once recognized model/stream activity was observed for this
+   * incarnation; the stall classifier uses this, not usage totals. */
+  modelOutputSeen?: boolean;
   createdAt: number;
   updatedAt: number;
   stoppedAt?: number;

--- a/packages/agent-teams/tests/test_teammate_package.py
+++ b/packages/agent-teams/tests/test_teammate_package.py
@@ -1712,6 +1712,9 @@ def test_provider_hang_silent_stall_tier() -> None:
     assert "modelOutputSeen: streamState.modelOutputSeen" in spawner
     assert "progress.usage" in state
     assert "if (progress.modelOutputSeen) teammate.modelOutputSeen = true;" in state
+    # Usage never sets the classifier: only streamed content does.
+    assert "if (parts.trim()) state.modelOutputSeen = true;" in spawner
+    assert "totalTokens ?? 0) > 0)) state.modelOutputSeen" not in spawner
     # The console marks the silent tier with the same effective threshold.
     assert "stallThresholdMs" in ui
     payload = run_node(

--- a/packages/agent-teams/tests/test_teammate_package.py
+++ b/packages/agent-teams/tests/test_teammate_package.py
@@ -1707,22 +1707,25 @@ def test_provider_hang_silent_stall_tier() -> None:
     assert "PI_TEAMMATE_SILENT_STALL_MS" in machine
     assert "stallThresholdMs" in machine and "hasModelOutput" in machine
     assert "stallNoticeBody" in machine
-    # Streaming usage reaches the roster so zero-token hangs are visible before shutdown.
-    assert "usage?: WorkerUsage" in spawner
-    assert "usage: streamState.usage" in spawner
+    # Streaming activity and usage reach the roster so hangs are visible before shutdown.
+    assert "modelOutputSeen?: boolean" in spawner
+    assert "modelOutputSeen: streamState.modelOutputSeen" in spawner
     assert "progress.usage" in state
+    assert "if (progress.modelOutputSeen) teammate.modelOutputSeen = true;" in state
     # The console marks the silent tier with the same effective threshold.
     assert "stallThresholdMs" in ui
     payload = run_node(
         f'''\
         import {{ hasModelOutput, stallThresholdMs, stallNoticeBody }} from "{(SRC / "team-machine.ts").as_uri()}";
         const now = 5 * 60_000;
-        const hung = {{ status: "working", createdAt: 0, lastOutputAt: 0, activeTool: undefined, usage: undefined }};
-        const longTool = {{ ...hung, activeTool: "bash: pio run -t upload", usage: undefined }};
-        const midWork = {{ ...hung, usage: {{ input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: 0.01 }} }};
+        const hung = {{ status: "working", createdAt: 0, lastOutputAt: 0, activeTool: undefined, modelOutputSeen: undefined, usage: undefined }};
+        const longTool = {{ ...hung, activeTool: "bash: pio run -t upload", modelOutputSeen: true }};
+        const activityNoUsage = {{ ...hung, modelOutputSeen: true, usage: undefined }};
+        const midWork = {{ ...hung, modelOutputSeen: true, usage: {{ input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15, cost: 0.01 }} }};
         console.log(JSON.stringify({{
           silentTier: stallThresholdMs(hung),
           longToolTier: stallThresholdMs(longTool),
+          activityTier: stallThresholdMs(activityNoUsage),
           modelOutputTier: stallThresholdMs(midWork),
           zeroOutputDetected: !hasModelOutput(hung),
           outputDetected: hasModelOutput(midWork),
@@ -1734,8 +1737,9 @@ def test_provider_hang_silent_stall_tier() -> None:
     )
     assert payload["zeroOutputDetected"] is True
     assert payload["outputDetected"] is True
-    # The provider-hang signature uses the shorter window; anything else keeps the default.
-    assert payload["silentTier"] < payload["longToolTier"] == payload["modelOutputTier"]
+    # The provider-hang signature uses the shorter window; recognized stream
+    # activity counts as output even when usage totals are absent.
+    assert payload["silentTier"] < payload["longToolTier"] == payload["activityTier"] == payload["modelOutputTier"]
     hung_body: str = payload["hungBody"]  # type: ignore[assignment]
     assert "No model output received yet" in hung_body
     assert "respawning a successor" in hung_body
@@ -1790,14 +1794,17 @@ def test_worker_tool_grant_is_visible_at_spawn() -> None:
         assert phrase in feature, phrase
     assert "resolveWorkerTools" in spawner and "WORKER_CAPABILITY_TOOLS" in spawner
     assert 'args.push("--tools", resolveWorkerTools(options.tools).join(","))' in spawner
-    # The roster records the grant before the first wake — both leader state
-    # and the worker-readable roster snapshot.
+    # The grant is flushed to both rosters before the kickoff can be consumed.
     assert "tools: resolveWorkerTools(agent.tools)" in machine
+    grant_index = machine.index("tools: resolveWorkerTools(agent.tools)")
+    spawn_window = machine[grant_index:grant_index + 1200]
+    assert spawn_window.index("publishStateSnapshot()") < spawn_window.index("spawnResident({")
     assert "status: t.status, tools: t.tools" in machine
     assert "tools?: string[]" in types
-    # Persisted in result details so historical renders survive session restarts.
+    # Persisted in result details so historical renders survive session restarts
+    # and stay truthful across teammate-name reuse (no live-state fallback).
     assert "details: { started: true, tools: granted }" in tools_src
-    assert "details?.tools ?? getTeammate(params.name)?.tools" in tools_src
+    assert "const tools = details?.tools;" in tools_src
     # Spawn surfaces name the granted list so missing read/bash is obvious immediately.
     assert "granted.join(\", \")" in tools_src
     assert "Tools: ${teammate.tools.join(", ")}" in ui
@@ -1920,8 +1927,10 @@ def test_idle_without_terminal_report_self_finalizes_before_escalating() -> None
     assert "idleNudgesSent" in machine
     # The worker-side send tool reinforces the rule at the exact moment of use.
     assert "does not end your assignment" in worker
-    # A prompt-less spawn is idle from birth instead of sticking in starting.
-    assert 'updateTeammate(input.name, { status: "idle" })' in machine
+    # A spawned teammate runs a kickoff turn, so status must stay "starting"
+    # until real stream events arrive: the old synchronous idle mark mislabeled
+    # an actively-running turn as idle and misrouted queued deliveries.
+    assert 'updateTeammate(input.name, { status: "idle" })' not in machine
 
 
 def test_worker_task_list_includes_roster_tail() -> None:


### PR DESCRIPTION
## What
Fixes the teammate status-truth bug behind today's lost-message pattern, switches the stall classifier from usage totals to recognized stream activity, and applies both findings from a two-agent analysis of PRs #17/#18.

## Why
Prompt-less spawns were marked idle at birth while their kickoff turn was already running. Progress promotion only transitions from starting, so the running turn stayed labeled idle: leader messages were queued instead of steered, delivered into the stdin of that same turn, and silently lost — the teammate kept reporting an empty board until a resend landed as a steer. Observed live three times.

## Changes
- Status truth: no synchronous idle mark; status flows starting→working→idle from stream events.
- Classifier: provider-hang tier keys on modelOutputSeen (recognized stream events; content-carrying message_end only); usage is diagnostics; empty artifacts never count.
- Ordering: tool grant flushed before the kickoff is written; historical spawn renders read persisted details only; readRoster shape includes tools; guidance typo fixed.
- BDD scenarios + behavioral tests for activity-without-usage classification and flush ordering; changeset minor.

## Review cycle
4 findings triaged over 1 baseline round + 1 bot flag, 3 adopted, 2 external/stale rejected; all checks green.
Full breakdown: https://github.com/FradSer/pi-packages/pull/19#issuecomment-5406714090

## Verification
- python3 -m pytest packages/agent-teams/tests/ — 72 passed
- pnpm test — 378 passed across monorepo
- tsc --noEmit on clean worktree with changes applied — 0 errors (main checkout carried unrelated parallel-session WIP)
- Independent baseline review + triage rounds; Code Terrier re-review on final head passed with no issues
