### PR TITLE
feat(packages): add skill-invocation guidance

### DIFF
--- a/.changeset/skill-prompts-guidance.md
+++ b/.changeset/skill-prompts-guidance.md
@@ -1,0 +1,5 @@
+---
+"pi-continual-learning": minor
+---
+
+Add layered skill-specific corrective guidance for expanded `/skill:<name>` invocations, with idempotent system injection and user-target custom context messages.

--- a/packages/pi-continual-learning/README.md
+++ b/packages/pi-continual-learning/README.md
@@ -61,6 +61,31 @@ Built-in defaults cover known-futile automation: interactive auth commands
 (`npm/pnpm/yarn login|adduser|logout`) and OTP-via-file/chat routing are
 blocked with guidance to hand those steps to the user's own terminal.
 
+### Skill prompt guidance
+
+`skillPrompts` adds corrective guidance when Pi expands a configured
+`/skill:<name>` invocation. The same four layers apply (user, user-local,
+project, project-local), with the innermost definition winning by skill name.
+`disabled` only affects tool-call policies, not skill prompts:
+
+```json
+{
+  "skillPrompts": {
+    "using-open-artifacts": {
+      "prompt": "Use coda0.com as the default instance unless the user specifies another host.",
+      "target": "system"
+    }
+  }
+}
+```
+
+`target: "system"` appends the prompt to the current system prompt. The
+`target: "user"` form delivers a hidden custom context message because Pi's
+`before_agent_start` hook cannot rewrite the already-expanded user message;
+both targets are matched only against Pi's complete expanded skill XML, not a
+raw `/skill:` command or arbitrary XML-looking text. Guidance is appended
+idempotently when a hook is evaluated more than once.
+
 ## Memory
 
 See `AGENTS.md` and `procedures/consolidate.md` for the memory loading rules,

--- a/packages/pi-continual-learning/examples/skill-prompts.harness.json
+++ b/packages/pi-continual-learning/examples/skill-prompts.harness.json
@@ -1,0 +1,8 @@
+{
+  "skillPrompts": {
+    "using-open-artifacts": {
+      "prompt": "Use coda0.com as the default instance unless the user specifies another host.",
+      "target": "system"
+    }
+  }
+}

--- a/packages/pi-continual-learning/extensions/guardrail-config.ts
+++ b/packages/pi-continual-learning/extensions/guardrail-config.ts
@@ -41,6 +41,13 @@ function readLayer(source: string, filePath: string): PolicyLayer | undefined {
     } else if (parsed.policies !== undefined) {
       layer.errors = [`"policies" must be an array`];
     }
+    if (parsed.skillPrompts !== undefined) {
+      if (parsed.skillPrompts && typeof parsed.skillPrompts === "object" && !Array.isArray(parsed.skillPrompts)) {
+        layer.skillPrompts = parsed.skillPrompts as Record<string, unknown>;
+      } else {
+        layer.errors = [...(layer.errors ?? []), `"skillPrompts" must be an object`];
+      }
+    }
     if (Array.isArray(parsed.disabled)) {
       layer.disabled = parsed.disabled.map(String);
     }

--- a/packages/pi-continual-learning/extensions/guardrail-engine.ts
+++ b/packages/pi-continual-learning/extensions/guardrail-engine.ts
@@ -53,11 +53,38 @@ function stringArray(value: unknown): string[] | undefined {
  * layer and remove matching policies everywhere. */
 export function mergeLayers(layers: PolicyLayer[]): ResolvedConfig {
   const byName = new Map<string, { policy: Policy; broken?: string }>();
+  const skillPrompts = new Map<string, { prompt: string; target: "system" | "user" }>();
   const disabled = new Set<string>();
   const errors: string[] = [];
 
   for (const layer of layers) {
     for (const name of layer.disabled ?? []) disabled.add(name);
+    for (const [name, raw] of Object.entries(layer.skillPrompts ?? {})) {
+      if (
+        name.length === 0 ||
+        name.length > 64 ||
+        !/^[a-z0-9-]+$/.test(name) ||
+        name.startsWith("-") ||
+        name.endsWith("-")
+      ) {
+        errors.push(`${layer.source}: skill prompt name "${name}" violates the Pi skill-name rules and was skipped`);
+        continue;
+      }
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        errors.push(`${layer.source}: skill prompt "${name}" must be an object and was skipped`);
+        continue;
+      }
+      const entry = raw as Record<string, unknown>;
+      if (typeof entry.prompt !== "string" || !entry.prompt.trim()) {
+        errors.push(`${layer.source}: skill prompt "${name}" needs a non-empty string prompt and was skipped`);
+        continue;
+      }
+      if (entry.target !== "system" && entry.target !== "user") {
+        errors.push(`${layer.source}: skill prompt "${name}" target must be system or user and was skipped`);
+        continue;
+      }
+      skillPrompts.set(name, { prompt: entry.prompt, target: entry.target });
+    }
     for (const raw of layer.policies ?? []) {
       if (!raw || typeof raw.name !== "string" || !raw.name.trim()) {
         errors.push(`${layer.source}: policy without a name was skipped`);
@@ -108,7 +135,11 @@ export function mergeLayers(layers: PolicyLayer[]): ResolvedConfig {
     if (regexps.length === 0 && patterns.length > 0) continue;
     policies.push({ ...entry.policy, regexps });
   }
-  return { policies, errors };
+  return {
+    policies,
+    skillPrompts: Object.fromEntries(skillPrompts),
+    errors,
+  };
 }
 
 function normalizePolicy(

--- a/packages/pi-continual-learning/extensions/guardrail-engine.ts
+++ b/packages/pi-continual-learning/extensions/guardrail-engine.ts
@@ -65,7 +65,8 @@ export function mergeLayers(layers: PolicyLayer[]): ResolvedConfig {
         name.length > 64 ||
         !/^[a-z0-9-]+$/.test(name) ||
         name.startsWith("-") ||
-        name.endsWith("-")
+        name.endsWith("-") ||
+        name.includes("--")
       ) {
         errors.push(`${layer.source}: skill prompt name "${name}" violates the Pi skill-name rules and was skipped`);
         continue;

--- a/packages/pi-continual-learning/extensions/guardrail-types.ts
+++ b/packages/pi-continual-learning/extensions/guardrail-types.ts
@@ -26,10 +26,19 @@ export interface Policy {
   source?: string;
 }
 
+export interface SkillPrompt {
+  /** Literal guidance to add when the named skill is expanded by Pi. */
+  prompt: string;
+  /** Where Pi should receive the guidance. */
+  target: "system" | "user";
+}
+
 export interface PolicyLayer {
   /** Human-readable origin, e.g. "~/.pi/agent/harness.json". */
   source: string;
   policies?: Array<Record<string, unknown>>;
+  /** Per-skill guidance, resolved by skill name with innermost precedence. */
+  skillPrompts?: Record<string, unknown>;
   disabled?: string[];
   /** Non-fatal load problems (bad JSON shape) reported once. */
   errors?: string[];
@@ -37,5 +46,6 @@ export interface PolicyLayer {
 
 export interface ResolvedConfig {
   policies: Array<Policy & { regexps: RegExp[] }>;
+  skillPrompts: Record<string, SkillPrompt>;
   errors: string[];
 }

--- a/packages/pi-continual-learning/extensions/guardrails.ts
+++ b/packages/pi-continual-learning/extensions/guardrails.ts
@@ -10,7 +10,7 @@
  */
 
 import fs from "node:fs";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { parseSkillBlock, type ExtensionAPI, type BeforeAgentStartEvent } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_POLICIES, evaluate, mergeLayers } from "./guardrail-engine.ts";
 import { configPaths, loadLayers } from "./guardrail-config.ts";
 import type { PolicyLayer, ResolvedConfig } from "./guardrail-types.ts";
@@ -27,7 +27,28 @@ function defaultLayer(): PolicyLayer {
   };
 }
 
+function appendSystemGuidance(systemPrompt: string, guidance: string): string {
+  if (systemPrompt.includes(guidance)) return systemPrompt;
+  return systemPrompt ? `${systemPrompt}\n\n${guidance}` : guidance;
+}
+
+export function skillPromptTarget(
+  event: Pick<BeforeAgentStartEvent, "prompt">,
+  config: ResolvedConfig,
+): { name: string; prompt: string; target: "system" | "user" } | undefined {
+  const skill = parseSkillBlock(event.prompt);
+  if (!skill) return undefined;
+  const guidance = config.skillPrompts[skill.name];
+  if (!guidance) return undefined;
+  return { name: skill.name, ...guidance };
+}
+
 let cached: { key: string; value: ResolvedWithPaths } | undefined;
+
+// Pi shares one context among before_agent_start handlers in a turn, while
+// creating a fresh event for each one. Module scope also covers an accidental
+// duplicate extension registration; each later turn receives a new context.
+const injectedUserPromptContexts = new WeakSet<object>();
 
 function resolveConfig(cwd: string, agentDir?: string): ResolvedWithPaths {
   const paths = configPaths(cwd, agentDir);
@@ -48,13 +69,35 @@ function resolveConfig(cwd: string, agentDir?: string): ResolvedWithPaths {
 }
 
 export default function registerGuardrails(pi: ExtensionAPI) {
+  pi.on("before_agent_start", (event, ctx) => {
+    const cwd = ctx.cwd || process.cwd();
+    const { config } = resolveConfig(cwd);
+    const matched = skillPromptTarget(event, config);
+    if (!matched) return undefined;
+
+    if (matched.target === "system") {
+      return { systemPrompt: appendSystemGuidance(event.systemPrompt, matched.prompt) };
+    }
+    if (injectedUserPromptContexts.has(ctx)) return undefined;
+    injectedUserPromptContexts.add(ctx);
+    return {
+      message: {
+        customType: "skill-prompt-guidance",
+        content: matched.prompt,
+        display: false,
+        details: { skill: matched.name, target: "user" },
+      },
+    };
+  });
+
   pi.on("tool_call", async (event, ctx) => {
     const cwd = ctx.cwd || process.cwd();
     const { config } = resolveConfig(cwd);
     const decision = evaluate(config, {
       toolName: event.toolName,
       args: (event.input ?? {}) as Record<string, unknown>,
-    });    if (!decision) return undefined;
+    });
+    if (!decision) return undefined;
 
     if (decision.action === "confirm") {
       if (!ctx.hasUI) {
@@ -78,6 +121,7 @@ export default function registerGuardrails(pi: ExtensionAPI) {
       const { config, paths } = resolveConfig(cwd);
       const lines = [
         `policies: ${config.policies.length ? config.policies.map((p) => p.name).join(", ") : "(none)"}`,
+        `skill prompts: ${Object.keys(config.skillPrompts).length ? Object.keys(config.skillPrompts).join(", ") : "(none)"}`,
         "built-in defaults are active unless disabled by name",
         "config paths:",
         `  ${paths.user}`,

--- a/packages/pi-continual-learning/features/skill-prompts.feature
+++ b/packages/pi-continual-learning/features/skill-prompts.feature
@@ -1,0 +1,36 @@
+Feature: Skill-invocation prompt guidance
+  The harness can layer corrective guidance by skill name. Guidance applies only
+  to Pi's fully expanded skill invocation, not raw commands or arbitrary text.
+
+  Scenario: Project skill prompt overrides the user layer
+    Given user and project harness.json files define the same skill prompt
+    When the expanded skill invocation reaches before_agent_start
+    Then the project definition is selected
+
+  Scenario: System guidance is appended once
+    Given a system-target skill prompt is configured
+    When the same expanded skill event is handled twice
+    Then the guidance is present in the system prompt only once
+
+  Scenario: Matching requires Pi's complete expanded skill XML
+    Given a skill prompt is configured
+    When before_agent_start receives a raw /skill command or malformed XML
+    Then no guidance is injected
+
+  Scenario: User-target guidance uses one custom context message per turn
+    Given a user-target skill prompt is configured
+    When duplicate handlers receive fresh expanded-skill events in the same turn
+    Then one hidden custom message carries the guidance
+    And a later turn receives the guidance again
+    And the original expanded user prompt is not rewritten
+
+  Scenario: Unknown and unconfigured skills pass through
+    Given no matching skill prompt is configured
+    When an expanded skill invocation reaches before_agent_start
+    Then the system prompt and messages remain unchanged
+
+  Scenario: System guidance is safe in a headless session
+    Given a system-target skill prompt is configured
+    And no interactive UI is available
+    When the expanded skill invocation reaches before_agent_start
+    Then guidance is appended without prompting or failing

--- a/packages/pi-continual-learning/tests/test_guardrails_integration.py
+++ b/packages/pi-continual-learning/tests/test_guardrails_integration.py
@@ -40,6 +40,26 @@ async function callTool(toolName, args, ctx) {
   return results.filter(Boolean);
 }
 
+async function callBefore(prompt, systemPrompt, ctx, onlyGuardrails = false) {
+  let currentSystemPrompt = systemPrompt;
+  const results = [];
+  const handlers = onlyGuardrails ? (hooks.before_agent_start ?? []).slice(-1) : (hooks.before_agent_start ?? []);
+  for (const fn of handlers) {
+    // Pi retains one context for a turn but creates a new event per handler.
+    const event = {
+      type: "before_agent_start",
+      prompt,
+      images: undefined,
+      systemPrompt: currentSystemPrompt,
+      systemPromptOptions: {},
+    };
+    const result = await fn(event, ctx);
+    results.push(result);
+    if (result?.systemPrompt !== undefined) currentSystemPrompt = result.systemPrompt;
+  }
+  return { event: { systemPrompt: currentSystemPrompt }, results: results.filter(Boolean) };
+}
+
 // ── temp project + isolated user dir ────────────────────────────────
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "guard-e2e-"));
 const project = path.join(tmp, "project");
@@ -113,7 +133,7 @@ fs.writeFileSync(
   );
   record("ui-policy-gated", {
     uiBlocked: uiEdit.length === 1 && uiEdit[0].block === true,
-    tokensMentioned: /design tokens|min\(100%/.test(uiEdit[0]?.reason ?? ""),
+    tokensMentioned: /design tokens|min\\(100%/.test(uiEdit[0]?.reason ?? ""),
     mdPassed: mdEdit.length === 0,
     oldTextTrapFixed: fixEdit.length === 0,
   });
@@ -204,7 +224,74 @@ await new Promise((r) => setTimeout(r, 20));
   });
 }
 
-// ── S6: /guardrails command reports surface, headless-safe ──────────
+// ── S6: layered skill prompt injection uses Pi's expanded skill shape ──
+fs.writeFileSync(
+  path.join(agentDir, "harness.json"),
+  JSON.stringify({
+    skillPrompts: {
+      review: { prompt: "outer guidance", target: "system" },
+      usernote: { prompt: "user guidance", target: "user" },
+    },
+    policies: [{
+      name: "block-curl-prod",
+      tools: ["bash"],
+      paths: ["command"],
+      pattern: "curl .*prod\\\\.example\\\\.com",
+      action: "block",
+      reason: "Prod curl is forbidden.",
+    }],
+  }),
+);
+fs.writeFileSync(
+  path.join(project, ".pi", "harness.json"),
+  JSON.stringify({
+    skillPrompts: {
+      review: { prompt: "inner guidance", target: "system" },
+    },
+    policies: [{
+      name: "ui-fixed-width",
+      tools: ["edit", "write"],
+      require: { path: "path", pattern: "\\\\.(tsx|css)$" },
+      paths: ["content", "newText", "edits.newText"],
+      patterns: ["width:\\\\s*\\\\d{3,}px"],
+      action: "block",
+      reason: "Use design tokens and min(100%, var(--token)).",
+    }],
+  }),
+);
+await new Promise((r) => setTimeout(r, 20));
+{
+  const expanded = '<skill name="review" location="/tmp/review/SKILL.md">\\nReferences are relative to /tmp/review.\\n\\nReview body\\n</skill>\\n\\ncheck this';
+  const first = await callBefore(expanded, "base system", baseCtx, true);
+  const second = await callBefore(expanded, first.event.systemPrompt, baseCtx, true);
+  const raw = await callBefore("/skill:review check this", "raw system", baseCtx, true);
+  const fake = await callBefore("<skill name=\\\"review\\\">arbitrary</skill>", "fake system", baseCtx, true);
+  const userExpanded = '<skill name="usernote" location="/tmp/usernote/SKILL.md">\\nReferences are relative to /tmp/usernote.\\n\\nBody\\n</skill>';
+  const user = await callBefore(userExpanded, "user system", baseCtx, true);
+  const userHandler = (hooks.before_agent_start ?? []).slice(-1)[0];
+  const sharedTurnCtx = { ...baseCtx };
+  const userEvent = () => ({
+    type: "before_agent_start",
+    prompt: userExpanded,
+    images: undefined,
+    systemPrompt: "user system",
+    systemPromptOptions: {},
+  });
+  const firstUser = await userHandler(userEvent(), sharedTurnCtx);
+  const duplicateUser = await userHandler(userEvent(), sharedTurnCtx);
+  const nextTurnUser = await userHandler(userEvent(), { ...baseCtx });
+  record("skill-prompts", {
+    projectWins: first.event.systemPrompt === "base system\\n\\ninner guidance",
+    idempotent: second.event.systemPrompt === first.event.systemPrompt,
+    rawIgnored: raw.event.systemPrompt === "raw system" && raw.results.length === 0,
+    malformedIgnored: fake.results.length === 0,
+    userMessage: user.results.length === 1 && user.results[0].message?.content === "user guidance" && user.results[0].message?.display === false,
+    userDedupedInTurn: firstUser?.message?.content === "user guidance" && duplicateUser === undefined,
+    userReinjectedNextTurn: nextTurnUser?.message?.content === "user guidance",
+  });
+}
+
+// ── S7: /guardrails command reports surface, headless-safe ──────────
 {
   let notified = "";
   const cmdCtx = { ...baseCtx, ui: { notify: (msg) => (notified = msg) } };
@@ -263,6 +350,13 @@ def test_s5_cache_invalidates_on_later_user_edit() -> None:
     assert s["freshRuleSeen"] and s["oldRuleRetired"]
 
 
-def test_s6_command_reports_surface() -> None:
+def test_s6_skill_prompts_are_layered_and_idempotent() -> None:
+    s = ALL["skill-prompts"]
+    assert s["projectWins"] and s["idempotent"]
+    assert s["rawIgnored"] and s["malformedIgnored"] and s["userMessage"]
+    assert s["userDedupedInTurn"] and s["userReinjectedNextTurn"]
+
+
+def test_s7_command_reports_surface() -> None:
     s = ALL["command-surface"]
     assert s["listsPolicies"] and s["showsPaths"]

--- a/packages/pi-continual-learning/tests/test_guardrails_integration.py
+++ b/packages/pi-continual-learning/tests/test_guardrails_integration.py
@@ -231,6 +231,7 @@ fs.writeFileSync(
     skillPrompts: {
       review: { prompt: "outer guidance", target: "system" },
       usernote: { prompt: "user guidance", target: "user" },
+      "bad--skill": { prompt: "must be rejected", target: "system" },
     },
     policies: [{
       name: "block-curl-prod",
@@ -299,6 +300,7 @@ await new Promise((r) => setTimeout(r, 20));
   record("command-surface", {
     listsPolicies: notified.includes("ui-fixed-width") && notified.includes("block-curl-prod"),
     showsPaths: notified.includes("harness.json") && notified.includes(".local"),
+    invalidSkillReported: notified.includes("bad--skill") && notified.includes("violates the Pi skill-name rules"),
   });
 }
 
@@ -359,4 +361,4 @@ def test_s6_skill_prompts_are_layered_and_idempotent() -> None:
 
 def test_s7_command_reports_surface() -> None:
     s = ALL["command-surface"]
-    assert s["listsPolicies"] and s["showsPaths"]
+    assert s["listsPolicies"] and s["showsPaths"] and s["invalidSkillReported"]


### PR DESCRIPTION
## What

Add skill-specific corrective guidance to the `pi-continual-learning` harness.

## Why

The harness already learns from durable memory and tool-call policy. Skill invocation is another reliable boundary: Pi has expanded a known skill, but the model has not yet started the turn. This lets projects correct skill-specific execution behavior without modifying a skill's source.

## Changes

- Add layered `harness.json.skillPrompts`, resolved by skill name with innermost precedence.
- Detect only Pi's canonical expanded skill XML using `parseSkillBlock`.
- Inject system-target guidance through `before_agent_start` system prompt chaining and user-target guidance through hidden custom context messages.
- Validate skill names to Pi parity, including consecutive-hyphen rejection.
- Add runner-accurate same-turn user-message dedupe, cross-turn reinjection, BDD scenarios, integration tests, documentation, and an Open Artifacts/coda0 example.

## Review cycle

One Code Terrier finding was adopted and fixed; final Code Terrier and Devin checks passed. Full breakdown: https://github.com/FradSer/pi-packages/pull/22#issuecomment-5420145507

## Verification

- `pnpm test` — 402 passed, 16 subtests passed
- `python3 -m pytest packages/pi-continual-learning/tests packages/pi-kit/tests -q`
- `npx tsc --noEmit -p tsconfig.extensions.json`
- `pnpm --dir packages/pi-continual-learning pack --dry-run`
- Runtime mock-ExtensionAPI scenarios for canonical XML detection, layered precedence, raw/malformed pass-through, target semantics, runner-accurate idempotency, and headless safety
