### PR TITLE
feat(pi-kit): shared tool lifecycle row contract + gathered kind

### DIFF
--- a/.changeset/context-gathered-label.md
+++ b/.changeset/context-gathered-label.md
@@ -1,0 +1,5 @@
+---
+"@fradser/pi-kit": minor
+---
+
+Add a "gathered" kind to `formatToolEventLabel` so context-extraction tools can render `[context] gathered · <summary>` lifecycle rows (first consumer: pi-git-agent's session_context).

--- a/packages/pi-kit/features/pi-kit.feature
+++ b/packages/pi-kit/features/pi-kit.feature
@@ -23,6 +23,13 @@ Feature: Shared pi-kit runtime helpers
     And terminal events are `[monitor] event · <description>`
     And synchronous listings support other tools as `[sessions] listed · <description>`
 
+  Scenario: Lifecycle tool renderers provide the shared started and event row contract
+    Given a tool renderer configured with pi-kit lifecycle primitives
+    When the renderer handles a started result
+    Then it owns an empty call slot and one width-bounded `[tool] started · <subject>` row
+    And when it handles an expanded event result it reveals bounded detail lines
+    And an error result is rendered as one plain error row without a lifecycle label
+
   Scenario: Agent task and message labels share pi-kit formatting
     Given an agent task and a teammate name
     When the shared display helpers format them

--- a/packages/pi-kit/src/index.ts
+++ b/packages/pi-kit/src/index.ts
@@ -34,13 +34,91 @@ export function formatAgentTaskName(prompt: string, fallback: string, maxLength 
   return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 3)}...`;
 }
 
-/** Format the compact two-row tool event label used by background operations. */
+/** Lifecycle row kind shared by background and coordination tools. */
+export type ToolLifecycleKind = "started" | "event";
+
+/** Shared lifecycle row specification. Consumers adapt it to Pi's TUI types. */
+export interface ToolLifecycleSpec {
+  kind: ToolLifecycleKind;
+  tool: string;
+  subject: string;
+  /** Optional semantic label such as `created`, `listed`, or `to @name`. */
+  label?: string;
+  details?: readonly string[];
+}
+
+/** Format the compact tool event label used by background operations. */
 export function formatToolEventLabel(
-  kind: "started" | "event" | "listed" | "created",
+  kind: ToolLifecycleKind | "listed" | "created" | "gathered",
   description: string,
   tool = "monitor",
 ): string {
-  return `[${tool}] ${kind} · ${description}`;
+  return `[${safeDisplayText(tool)}] ${kind} · ${safeDisplayText(description)}`;
+}
+
+/** Build the common one-line lifecycle title for a tool result. */
+export function formatToolLifecycleTitle(spec: ToolLifecycleSpec): string {
+  const prefix = spec.label ?? spec.kind;
+  return `[${safeDisplayText(spec.tool)}] ${safeDisplayText(prefix)} · ${safeDisplayText(spec.subject)}`;
+}
+
+/** Build a started-row specification. */
+export function startedToolLifecycle(tool: string, subject: string): ToolLifecycleSpec {
+  return { kind: "started", tool, subject };
+}
+
+/** Build an event-row specification with optional expandable details. */
+export function eventToolLifecycle(
+  tool: string,
+  subject: string,
+  options: { label?: string; details?: readonly string[] } = {},
+): ToolLifecycleSpec {
+  return { kind: "event", tool, subject, label: options.label, details: options.details };
+}
+
+/** Return a bounded lifecycle detail block for an expanded result. */
+export function formatToolLifecycleDetails(spec: ToolLifecycleSpec, maxLines = 50): string[] {
+  return (spec.details ?? []).slice(0, Math.max(0, maxLines)).map((line) => safeDisplayText(line));
+}
+
+/** Return the first safe non-empty line from a failed tool result. */
+export function formatToolErrorLine(value: unknown, fallback = "Tool failed."): string {
+  const line = safeDisplayText(value).split("\n").find((entry) => entry.trim());
+  return line?.trim() || fallback;
+}
+
+/** Pi-independent adapters for the shared started/event row contract. */
+export interface ToolLifecycleRenderOptions<T> {
+  width: number;
+  expanded?: boolean;
+  expandHint?: string;
+  titleStyle: (text: string) => string;
+  detailStyle: (text: string) => string;
+  truncate: (text: string, width: number) => string;
+  line: (text: string) => T;
+}
+
+/**
+ * Render one lifecycle row and, when expanded, its bounded detail lines.
+ * Consumers provide Pi's Text/Box adapter, theme, and ANSI-aware truncator;
+ * pi-kit owns the started-vs-event behavior so extensions cannot drift.
+ */
+export function renderToolLifecycle<T>(
+  spec: ToolLifecycleSpec,
+  options: ToolLifecycleRenderOptions<T>,
+): T[] {
+  if (options.width <= 0) return [];
+  const title = options.titleStyle(formatToolLifecycleTitle(spec));
+  const details = formatToolLifecycleDetails(spec);
+  const collapsed = spec.kind === "started" || !options.expanded;
+  if (collapsed) {
+    const hint = spec.kind === "event" && details.length > 0 ? (options.expandHint ?? "") : "";
+    return [options.line(options.truncate(`${title}${hint}`, options.width))];
+  }
+  return [
+    options.line(options.truncate(title, options.width)),
+    ...details.map((detail) => options.line(options.truncate(options.detailStyle(detail), options.width))),
+  ];
 }
 
 /**

--- a/packages/pi-kit/tests/test_pi_kit.py
+++ b/packages/pi-kit/tests/test_pi_kit.py
@@ -159,13 +159,38 @@ def test_shared_termination_escalates_after_close_grace_period() -> None:
 def test_tool_event_labels_share_the_compact_monitor_pattern() -> None:
     result = run_typescript(
         f"""
-        import {{ formatToolEventLabel }} from {json.dumps((SRC / "index.ts").as_uri())};
+        import {{
+          eventToolLifecycle,
+          formatToolEventLabel,
+          formatToolLifecycleTitle,
+          renderToolLifecycle,
+          startedToolLifecycle,
+        }} from {json.dumps((SRC / "index.ts").as_uri())};
         console.log(JSON.stringify({{
           started: formatToolEventLabel("started", "运行 monitor 包测试"),
           event: formatToolEventLabel("event", "运行 monitor 包测试"),
           listed: formatToolEventLabel("listed", "2 other sessions in pi-packages", "sessions"),
           agentEvent: formatToolEventLabel("event", "@scribe shut down", "agent"),
           created: formatToolEventLabel("created", "Fix the login flow", "board"),
+          gathered: formatToolEventLabel("gathered", "3 requests since last commit", "context"),
+          startedTitle: formatToolLifecycleTitle(startedToolLifecycle("agent", "@audit · review")),
+          createdTitle: formatToolLifecycleTitle(eventToolLifecycle("board", "Fix login", {{ label: "created" }})),
+          startedRows: renderToolLifecycle(startedToolLifecycle("agent", "@audit · review"), {{
+            width: 80,
+            expanded: false,
+            titleStyle: (text) => text,
+            detailStyle: (text) => text,
+            truncate: (text, width) => text.slice(0, width),
+            line: (text) => text,
+          }}),
+          eventRows: renderToolLifecycle(eventToolLifecycle("board", "Fix login", {{ details: ["status=success"] }}), {{
+            width: 80,
+            expanded: true,
+            titleStyle: (text) => text,
+            detailStyle: (text) => text,
+            truncate: (text, width) => text.slice(0, width),
+            line: (text) => text,
+          }}),
         }}));
         """
     )
@@ -175,6 +200,11 @@ def test_tool_event_labels_share_the_compact_monitor_pattern() -> None:
         "listed": "[sessions] listed · 2 other sessions in pi-packages",
         "agentEvent": "[agent] event · @scribe shut down",
         "created": "[board] created · Fix the login flow",
+        "gathered": "[context] gathered · 3 requests since last commit",
+        "startedTitle": "[agent] started · @audit · review",
+        "createdTitle": "[board] created · Fix login",
+        "startedRows": ["[agent] started · @audit · review"],
+        "eventRows": ["[board] event · Fix login", "status=success"],
     }
 
 


### PR DESCRIPTION
## Summary
Extract the shared tool lifecycle row contract into `@fradser/pi-kit` so background/coordination tools render one compact started/event row with bounded expandable details, and extensions cannot drift:

- `ToolLifecycleSpec` + `startedToolLifecycle` / `eventToolLifecycle` builders
- `renderToolLifecycle<T>` — Pi-independent adapter (consumer supplies theme callbacks, ANSI truncator, line constructor)
- `formatToolLifecycleTitle` / `formatToolLifecycleDetails` / `formatToolErrorLine` helpers, safe display truncation
- `formatToolEventLabel` gains a **gathered** kind for context-extraction tools (`[context] gathered · <summary>`; first consumer: pi-git-agent session_context)

## Affected packages
- `@fradser/pi-kit` (minor via `.changeset/context-gathered-label.md`)

## Verification
- `python3 -m pytest packages/pi-kit/tests -q`
- `npx tsc --noEmit -p tsconfig.extensions.json`
- 102 tests pass across pi-kit + agent-teams on the stacked chain

## Release impact
Changeset included. Foundation PR: `wip/agent-teams-routing-render` (#25) is stacked on this branch.

## README changes
None.