### PR TITLE
feat(utils): EnterWorktree/ExitWorktree session switching + worktree-aware @ completions

### DIFF
--- a/.changeset/pi-utils-enter-worktree.md
+++ b/.changeset/pi-utils-enter-worktree.md
@@ -1,0 +1,8 @@
+---
+"@fradser/pi-utils": minor
+---
+
+Add Claude Code-style EnterWorktree and ExitWorktree session switching. Pi can
+create or enter a git worktree through a replacement session, rebind built-in
+tools and @ completions to that worktree cwd, return to the parent session, and
+optionally clean up worktrees created by Pi.

--- a/.changeset/utils-worktree-aware-completions.md
+++ b/.changeset/utils-worktree-aware-completions.md
@@ -1,0 +1,8 @@
+---
+"@fradser/pi-utils": minor
+---
+
+Add git worktree-aware @ completions: editor file suggestions now hide paths
+that resolve inside another git worktree. A session in main never sees linked
+worktree contents, and a session inside a linked worktree never sees sibling
+worktrees or the main checkout.

--- a/packages/utils/AGENTS.md
+++ b/packages/utils/AGENTS.md
@@ -4,7 +4,8 @@
 
 `packages/utils/` publishes `@fradser/pi-utils`, a native Pi extension. `index.ts`
 only wires the focused modules in `extensions/`: `/continue`, `/effort`, `/init`,
-`/sessions`/`/recap`, and the git worktree redirect. BDD contracts live in
+`/sessions`/`/recap`, git worktree path redirect, worktree-aware `@`
+completions, and EnterWorktree/ExitWorktree session switching. BDD contracts live in
 `features/`; executable Python tests and runtime harnesses live in `tests/`.
 The published package is limited by `package.json`'s `files` list (`index.ts`,
 `extensions/`, and `README.md`).
@@ -35,5 +36,5 @@ runtime dependency, not a peer dependency.
 For behavior changes, update the matching `.feature` scenario before changing
 implementation, then add or update tests under `tests/`. Cover command parsing,
 continuation edge cases, supported thinking levels, safe worktree rewriting,
-and session registry behavior. Add a Changeset for published changes and use
+worktree session replacement, and session registry behavior. Add a Changeset for published changes and use
 the repository's Conventional Commit scopes (for example `feat(packages):`).

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,6 +1,6 @@
 # Utils Pi Package
 
-A pi-native package offering `/effort` for setting model thinking levels, `/继续` (`/continue`) for resuming interrupted tasks or continuing based on recommendations, `/init` for creating or updating scoped `AGENTS.md` contributor guides, multi-session directory awareness (`/sessions`), plus a git worktree path redirect.
+A pi-native package offering `/effort` for setting model thinking levels, `/继续` (`/continue`) for resuming interrupted tasks or continuing based on recommendations, `/init` for creating or updating scoped `AGENTS.md` contributor guides, multi-session directory awareness (`/sessions`), git worktree session switching, plus git worktree path and `@` completion isolation.
 
 ## Structure
 
@@ -13,7 +13,9 @@ utils/
 │   ├── effort.ts         — /effort thinking-level menu
 │   ├── init.ts           — /init repository guide generation
 │   ├── sessions.ts       — /sessions directory awareness + listing tool
-│   └── worktree.ts       — git worktree add path redirect
+│   ├── worktree.ts       — git worktree add path redirect
+│   ├── worktree-completion.ts — worktree-aware @ filtering
+│   └── worktree-session.ts — EnterWorktree / ExitWorktree session switching
 ├── features/             — BDD contract
 ├── tests/                — Package E2E tests
 └── README.md
@@ -108,6 +110,43 @@ For safety, it only rewrites the direct `git worktree add` form. Commands with
 shell operators, redirections, substitutions, expansions, malformed quoting,
 unknown options, or extra arguments are left unchanged rather than being
 partially rewritten.
+
+## Git worktree-aware @ completions
+
+Editor file suggestions (`@`) are filtered to the session's own git worktree:
+a session in main never suggests linked worktree contents, and a session
+inside a linked worktree never suggests sibling worktrees or the main
+checkout. Worktree roots are discovered once per session via
+`git worktree list --porcelain`; outside a git repository nothing is filtered.
+Quoted and `@`-prefixed values are resolved (relative, absolute, and `~/`
+forms) before the containment check.
+
+## EnterWorktree / ExitWorktree
+
+Pi cannot mutate the current runtime's `cwd` in place. These commands use Pi's
+session replacement API so the built-in `read`, `edit`, `bash`, and `@` tools
+are all rebound to the selected worktree:
+
+```text
+/enter-worktree feature-auth
+/enter-worktree {"path":".pi/worktrees/existing"}
+/exit-worktree
+```
+
+`/enter-worktree` creates a managed worktree at `.pi/worktrees/<name>` on a
+`pi/worktree/<name>` branch, or enters an existing registered git worktree when
+`path` is supplied. The replacement session preserves the current conversation
+and records the parent session. The LLM-facing `enter_worktree` and
+`exit_worktree` tools queue these commands and report `queued` until the session
+replacement is applied. Their TUI uses the same pi-kit lifecycle style as
+`monitor_start`: an empty tool-call row followed by one compact event row,
+for example `[worktree] enter · feature-auth` or
+`[worktree] exit · current worktree`.
+
+`/exit-worktree` returns to the parent session. For worktrees created by Pi, it
+asks whether to keep or remove the worktree; dirty work is kept unless the user
+explicitly chooses forced removal. Existing worktrees are never removed by
+this command.
 
 ## License
 

--- a/packages/utils/extensions/worktree-completion.ts
+++ b/packages/utils/extensions/worktree-completion.ts
@@ -1,0 +1,226 @@
+/**
+ * pi-utils-fradser — git worktree-aware @ completions.
+ *
+ * Wraps the built-in editor autocomplete provider and drops suggestions whose
+ * paths resolve inside another git worktree: a session in main never sees
+ * linked worktree contents, and a session inside a linked worktree never sees
+ * sibling worktrees or the main checkout.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+
+export interface WorktreeRoots {
+	currentRoot: string | null;
+	foreignRoots: string[];
+}
+
+function canonicalize(candidate: string): string {
+	try {
+		return fs.realpathSync(candidate);
+	} catch {
+		return path.resolve(candidate);
+	}
+}
+
+/**
+ * Realpath the deepest existing ancestor and append the non-existent remainder,
+ * so candidates under symlinked directories still land in the canonical space
+ * even when their leaf does not exist.
+ */
+const canonicalCache = new Map<string, string>();
+
+function canonicalizeBestEffort(candidate: string): string {
+	const hit = canonicalCache.get(candidate);
+	if (hit !== undefined) return hit;
+
+	let remainder = "";
+	let current = candidate;
+	let resolved: string | null = null;
+	for (;;) {
+		try {
+			resolved = `${fs.realpathSync(current)}${remainder}`;
+			break;
+		} catch {
+			const parent = path.dirname(current);
+			if (parent === current) break;
+			remainder = `${path.sep}${path.basename(current)}${remainder}`;
+			current = parent;
+		}
+	}
+	if (resolved === null) return candidate;
+
+	if (canonicalCache.size >= 1024) canonicalCache.clear();
+	canonicalCache.set(candidate, resolved);
+	return resolved;
+}
+
+function runGit(cwd: string, args: string[]): string | null {
+	try {
+		return execFileSync("git", args, {
+			cwd,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Collect the current session's worktree root plus every other root reported
+ * by `git worktree list --porcelain`. Outside a git repository both values are
+ * empty/null and filtering is disabled.
+ */
+export function collectWorktreeRoots(cwd: string): WorktreeRoots {
+	const porcelain = runGit(cwd, ["worktree", "list", "--porcelain"]);
+	if (!porcelain) return { currentRoot: null, foreignRoots: [] };
+
+	interface Entry {
+		bare: boolean;
+		root: string;
+	}
+	const entries: Entry[] = [];
+	for (const line of porcelain.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			entries.push({ bare: false, root: canonicalize(line.slice(9)) });
+		} else if (line.trim() === "bare") {
+			const last = entries[entries.length - 1];
+			if (last) last.bare = true;
+		}
+	}
+
+	const topLevel = runGit(cwd, ["rev-parse", "--show-toplevel"]);
+	let currentRoot = topLevel ? canonicalize(topLevel) : null;
+	if (!currentRoot) {
+		// A session opened at a bare repository has no toplevel; treat the bare
+		// entry as current when the cwd sits on it.
+		const canonicalCwd = canonicalizeBestEffort(cwd);
+		currentRoot =
+			entries.find((entry) => entry.bare && entry.root === canonicalCwd)?.root ??
+			null;
+	}
+	const foreignRoots =
+		currentRoot === null
+			? []
+			: entries
+					.map((entry) => entry.root)
+					.filter((root) => root !== currentRoot);
+	return { currentRoot, foreignRoots };
+}
+
+/**
+ * Strip @ prefix, surrounding quotes, and trailing slash into a plain path.
+ * pi-tui wraps values verbatim in quotes without escaping, so no unquoting of
+ * backslash sequences happens here (Windows separators stay intact).
+ */
+export function suggestionToPath(value: string): string {
+	let candidate = value.startsWith("@") ? value.slice(1) : value;
+	if (
+		candidate.length >= 2 &&
+		candidate.startsWith('"') &&
+		candidate.endsWith('"')
+	) {
+		candidate = candidate.slice(1, -1);
+	}
+	return candidate.replace(/\/+$/, "");
+}
+
+function isInside(candidate: string, root: string): boolean {
+	return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+/** True when the suggestion resolves inside a non-current git worktree root. */
+export function isInForeignWorktree(
+	value: string,
+	basePath: string,
+	roots: WorktreeRoots,
+): boolean {
+	if (roots.foreignRoots.length === 0) return false;
+
+	let candidate = suggestionToPath(value);
+	if (!candidate) return false;
+
+	if (candidate.startsWith("~/")) {
+		candidate = path.join(os.homedir(), candidate.slice(2));
+	}
+	const base = canonicalizeBestEffort(basePath);
+	const absolute = path.isAbsolute(candidate)
+		? candidate
+		: path.resolve(base, candidate);
+
+	for (const root of roots.foreignRoots) {
+		if (isInside(canonicalizeBestEffort(absolute), root)) return true;
+	}
+	return false;
+}
+
+export function filterForeignWorktreeItems<T extends AutocompleteItem>(
+	items: T[],
+	basePath: string,
+	roots: WorktreeRoots,
+): T[] {
+	if (roots.foreignRoots.length === 0) return items;
+	return items.filter(
+		(item) => !isInForeignWorktree(item.value, basePath, roots),
+	);
+}
+
+let registered = false;
+let cache: { cwd: string; roots: WorktreeRoots } | null = null;
+
+/** Memoized discovery keyed by cwd: git runs at most once per session. */
+export function getWorktreeRoots(cwd: string): WorktreeRoots {
+	if (!cache || cache.cwd !== cwd) {
+		cache = { cwd, roots: collectWorktreeRoots(cwd) };
+	}
+	return cache.roots;
+}
+
+export default function registerWorktreeCompletion(pi: ExtensionAPI): void {
+	pi.on("session_start", (_event, ctx) => {
+		if (registered) return;
+		registered = true;
+
+		ctx.ui.addAutocompleteProvider((current) => ({
+			async getSuggestions(lines, cursorLine, cursorCol, options) {
+				const result = await current.getSuggestions(
+					lines,
+					cursorLine,
+					cursorCol,
+					options,
+				);
+				if (!result || result.items.length === 0) return result;
+
+				const roots = getWorktreeRoots(ctx.cwd);
+				if (roots.foreignRoots.length === 0) return result;
+				return {
+					...result,
+					items: filterForeignWorktreeItems(result.items, ctx.cwd, roots),
+				};
+			},
+			applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+				return current.applyCompletion(
+					lines,
+					cursorLine,
+					cursorCol,
+					item,
+					prefix,
+				);
+			},
+			shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
+				return (
+					current.shouldTriggerFileCompletion?.(
+						lines,
+						cursorLine,
+						cursorCol,
+					) ?? true
+				);
+			},
+		}));
+	});
+}

--- a/packages/utils/extensions/worktree-completion.ts
+++ b/packages/utils/extensions/worktree-completion.ts
@@ -173,6 +173,13 @@ export function filterForeignWorktreeItems<T extends AutocompleteItem>(
 let registered = false;
 let cache: { cwd: string; roots: WorktreeRoots } | null = null;
 
+/**
+ * Live session cwd. Session replacement (EnterWorktree) swaps sessions without
+ * re-loading extensions, so the captured session_start context goes stale;
+ * every session_start refreshes the cwd the filter resolves against.
+ */
+let activeCwd: string | null = null;
+
 /** Memoized discovery keyed by cwd: git runs at most once per session. */
 export function getWorktreeRoots(cwd: string): WorktreeRoots {
 	if (!cache || cache.cwd !== cwd) {
@@ -183,6 +190,7 @@ export function getWorktreeRoots(cwd: string): WorktreeRoots {
 
 export default function registerWorktreeCompletion(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
+		activeCwd = ctx.cwd;
 		if (registered) return;
 		registered = true;
 
@@ -196,11 +204,13 @@ export default function registerWorktreeCompletion(pi: ExtensionAPI): void {
 				);
 				if (!result || result.items.length === 0) return result;
 
-				const roots = getWorktreeRoots(ctx.cwd);
+				const cwd = activeCwd;
+				if (!cwd) return result;
+				const roots = getWorktreeRoots(cwd);
 				if (roots.foreignRoots.length === 0) return result;
 				return {
 					...result,
-					items: filterForeignWorktreeItems(result.items, ctx.cwd, roots),
+					items: filterForeignWorktreeItems(result.items, cwd, roots),
 				};
 			},
 			applyCompletion(lines, cursorLine, cursorCol, item, prefix) {

--- a/packages/utils/extensions/worktree-session.ts
+++ b/packages/utils/extensions/worktree-session.ts
@@ -1,0 +1,480 @@
+/**
+ * pi-utils-fradser — Claude Code-style git worktree session switching.
+ *
+ * Pi binds its built-in tools to the session cwd, so entering a worktree
+ * creates a replacement session with that cwd instead of mutating process.cwd.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
+	type Theme,
+} from "@earendil-works/pi-coding-agent";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { Text, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+	eventToolLifecycle,
+	formatToolErrorLine,
+	renderToolLifecycle,
+	safeDisplayText,
+} from "@fradser/pi-kit";
+import { Type } from "typebox";
+
+export const WORKTREE_SESSION_ENTRY = "pi-utils-worktree-session";
+
+interface WorktreeToolResult {
+	content: Array<{ text?: string; type: string }>;
+}
+
+function worktreeToolText(result: WorktreeToolResult): string {
+	return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+function renderWorktreeToolResult(
+	result: WorktreeToolResult,
+	options: { expanded?: boolean },
+	theme: Pick<Theme, "bold" | "fg">,
+	context: { isError?: boolean },
+	subject: string,
+): { invalidate: () => void; render: (width: number) => string[] } | Text {
+	if (context.isError) {
+		return new Text(theme.fg("error", formatToolErrorLine(worktreeToolText(result))), 0, 0);
+	}
+	const separator = subject.indexOf(" ");
+	const action = separator === -1 ? subject : subject.slice(0, separator);
+	const target = separator === -1 ? "" : subject.slice(separator + 1);
+	const spec = eventToolLifecycle("worktree", target, { label: action });
+	return {
+		invalidate: () => {},
+		render: (width) => renderToolLifecycle(spec, {
+			width,
+			expanded: options.expanded,
+			titleStyle: (line) => theme.fg("toolTitle", theme.bold(line)),
+			detailStyle: (line) => theme.fg("customMessageText", line),
+			truncate: truncateToWidth,
+			line: (line) => line,
+		}),
+	};
+}
+
+export interface WorktreeRecord {
+	bare: boolean;
+	branch?: string;
+	root: string;
+}
+
+export interface WorktreeSessionState {
+	baseCommit: string;
+	branch?: string;
+	created: boolean;
+	parentSession: string;
+	path: string;
+	repoRoot: string;
+}
+
+export interface EnterWorktreeRequest {
+	name?: string;
+	path?: string;
+}
+
+export interface CreatedEnterTarget {
+	baseCommit: string;
+	created: true;
+	name: string;
+	path: string;
+	repoRoot: string;
+}
+
+export interface ExistingEnterTarget {
+	baseCommit: string;
+	created: false;
+	name?: string;
+	path: string;
+	record?: WorktreeRecord;
+	repoRoot: string;
+}
+
+export type EnterTarget = CreatedEnterTarget | ExistingEnterTarget;
+
+interface GitResult {
+	status: number | null;
+	stderr: string;
+	stdout: string;
+}
+
+function runGit(cwd: string, args: string[]): GitResult {
+	const result = spawnSync("git", ["-C", cwd, ...args], {
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	return {
+		status: result.status,
+		stdout: result.stdout ?? "",
+		stderr: result.stderr ?? "",
+	};
+}
+
+function canonicalize(candidate: string): string {
+	try {
+		return fs.realpathSync(candidate);
+	} catch {
+		return path.resolve(candidate);
+	}
+}
+
+export function parseWorktreeList(output: string): WorktreeRecord[] {
+	const entries: WorktreeRecord[] = [];
+	for (const line of output.split("\n")) {
+		if (line.startsWith("worktree ")) {
+			entries.push({ bare: false, root: canonicalize(line.slice(9)) });
+			continue;
+		}
+		const current = entries[entries.length - 1];
+		if (!current) continue;
+		if (line.trim() === "bare") current.bare = true;
+		if (line.startsWith("branch ")) current.branch = line.slice(7).replace(/^refs\/heads\//, "");
+	}
+	return entries;
+}
+
+export function listWorktrees(cwd: string): WorktreeRecord[] {
+	const result = runGit(cwd, ["worktree", "list", "--porcelain"]);
+	return result.status === 0 ? parseWorktreeList(result.stdout) : [];
+}
+
+function currentWorktreeRoot(cwd: string): string | null {
+	const result = runGit(cwd, ["rev-parse", "--show-toplevel"]);
+	return result.status === 0 && result.stdout.trim()
+		? canonicalize(result.stdout.trim())
+		: null;
+}
+
+function projectRoot(cwd: string, entries: WorktreeRecord[]): string | null {
+	const current = currentWorktreeRoot(cwd);
+	const canonicalCwd = canonicalize(cwd);
+	if (!current && entries.some((entry) => entry.bare && entry.root === canonicalCwd)) return null;
+
+	const commonDir = runGit(cwd, ["rev-parse", "--git-common-dir"]);
+	if (commonDir.status === 0 && commonDir.stdout.trim()) {
+		const gitDir = canonicalize(path.resolve(cwd, commonDir.stdout.trim()));
+		if (path.basename(gitDir) === ".git") return path.dirname(gitDir);
+	}
+	return current ? entries.find((entry) => entry.root === current)?.root ?? current : null;
+}
+
+function safeName(name: string): string | null {
+	const normalized = name
+		.trim()
+		.replace(/[\\/]+/g, "-")
+		.replace(/[^A-Za-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return normalized && normalized !== "." && normalized !== ".." ? normalized : null;
+}
+
+function resolvePathFrom(cwd: string, value: string): string {
+	return canonicalize(path.isAbsolute(value) ? value : path.resolve(cwd, value));
+}
+
+function findRegisteredWorktree(cwd: string, value: string): WorktreeRecord | null {
+	const target = resolvePathFrom(cwd, value);
+	return listWorktrees(cwd).find((entry) => entry.root === target) ?? null;
+}
+
+function currentHead(cwd: string): string | null {
+	const result = runGit(cwd, ["rev-parse", "HEAD"]);
+	return result.status === 0 && result.stdout.trim() ? result.stdout.trim() : null;
+}
+
+export function resolveEnterTarget(
+	cwd: string,
+	request: EnterWorktreeRequest,
+): EnterTarget | { error: string } {
+	if (request.name && request.path) return { error: "provide either name or path, not both" };
+	const entries = listWorktrees(cwd);
+	const repoRoot = projectRoot(cwd, entries);
+	if (!repoRoot) return { error: "EnterWorktree requires a non-bare git repository" };
+
+	if (request.path) {
+		const record = findRegisteredWorktree(cwd, request.path);
+		if (!record) return { error: `path is not a registered git worktree: ${request.path}` };
+		const baseCommit = currentHead(cwd);
+		if (!baseCommit) return { error: "the current worktree has no commit" };
+		return { created: false, path: record.root, record, repoRoot, baseCommit };
+	}
+
+	const name = safeName(request.name ?? `pi-${Date.now().toString(36)}`);
+	if (!name) return { error: "worktree name is empty after sanitization" };
+	const target = path.join(repoRoot, ".pi", "worktrees", name);
+	const targetRoot = canonicalize(target);
+	const existing = entries.find((entry) => entry.root === targetRoot);
+	if (existing) {
+		const baseCommit = currentHead(cwd);
+		if (!baseCommit) return { error: "the current worktree has no commit" };
+		return { created: false, name, path: existing.root, record: existing, repoRoot, baseCommit };
+	}
+	if (fs.existsSync(target)) return { error: `path exists but is not a registered git worktree: ${target}` };
+
+	const baseCommit = currentHead(cwd);
+	if (!baseCommit) return { error: "EnterWorktree requires at least one commit" };
+	return { created: true, name, path: target, repoRoot, baseCommit };
+}
+
+function createWorktree(
+	target: CreatedEnterTarget,
+): WorktreeSessionState | { error: string } {
+	const branch = `pi/worktree/${target.name}`;
+	fs.mkdirSync(path.dirname(target.path), { recursive: true });
+	const result = runGit(target.repoRoot, ["worktree", "add", target.path, "-b", branch, target.baseCommit]);
+	if (result.status !== 0) {
+		return { error: result.stderr.trim() || result.stdout.trim() || "git worktree add failed" };
+	}
+	return {
+		baseCommit: target.baseCommit,
+		branch,
+		created: true,
+		parentSession: "",
+		path: canonicalize(target.path),
+		repoRoot: target.repoRoot,
+	};
+}
+
+function isWorktreeSessionState(data: unknown): data is WorktreeSessionState {
+	if (!data || typeof data !== "object") return false;
+	const value = data as Partial<WorktreeSessionState>;
+	return (
+		typeof value.baseCommit === "string" &&
+		typeof value.created === "boolean" &&
+		typeof value.parentSession === "string" &&
+		typeof value.path === "string" &&
+		typeof value.repoRoot === "string"
+	);
+}
+
+export function readWorktreeSessionState(ctx: Pick<ExtensionContext, "sessionManager">): WorktreeSessionState | null {
+	const branch = ctx.sessionManager.getBranch();
+	for (let index = branch.length - 1; index >= 0; index -= 1) {
+		const entry = branch[index];
+		if (entry?.type !== "custom" || entry.customType !== WORKTREE_SESSION_ENTRY) continue;
+		return isWorktreeSessionState(entry.data) ? entry.data : null;
+	}
+	return null;
+}
+
+function worktreeHasChanges(state: WorktreeSessionState): boolean {
+	const status = runGit(state.path, ["status", "--porcelain", "--untracked-files=all"]);
+	if (status.status !== 0 || status.stdout.trim()) return true;
+	const commits = runGit(state.path, ["rev-list", "--count", `${state.baseCommit}..HEAD`]);
+	return commits.status !== 0 || Number.parseInt(commits.stdout.trim(), 10) > 0;
+}
+
+function removeWorktree(state: WorktreeSessionState): string | null {
+	const remove = runGit(state.repoRoot, ["worktree", "remove", "--force", state.path]);
+	if (remove.status !== 0) return remove.stderr.trim() || remove.stdout.trim() || "worktree removal failed";
+	if (state.branch) {
+		const branch = runGit(state.repoRoot, ["branch", "-D", state.branch]);
+		if (branch.status !== 0) return branch.stderr.trim() || branch.stdout.trim() || "branch removal failed";
+	}
+	runGit(state.repoRoot, ["worktree", "prune"]);
+	return null;
+}
+
+function formatTargetLabel(state: WorktreeSessionState): string {
+	return `${state.path}${state.branch ? ` (${state.branch})` : ""}`;
+}
+
+async function switchIntoWorktree(ctx: ExtensionCommandContext, request: EnterWorktreeRequest): Promise<void> {
+	const sourceSession = ctx.sessionManager.getSessionFile();
+	if (!sourceSession) {
+		ctx.ui.notify("EnterWorktree requires a persisted Pi session.", "error");
+		return;
+	}
+	const target = resolveEnterTarget(ctx.cwd, request);
+	if ("error" in target) {
+		ctx.ui.notify(target.error, "error");
+		return;
+	}
+	if (canonicalize(ctx.cwd) === canonicalize(target.path)) {
+		ctx.ui.notify("Already inside the requested worktree.", "info");
+		return;
+	}
+
+	let state: WorktreeSessionState;
+	if (target.created) {
+		const created = createWorktree(target);
+		if ("error" in created) {
+			ctx.ui.notify(created.error, "error");
+			return;
+		}
+		state = created;
+	} else {
+		state = {
+			baseCommit: target.baseCommit,
+			branch: target.record?.branch,
+			created: false,
+			parentSession: "",
+			path: target.path,
+			repoRoot: target.repoRoot,
+		};
+	}
+	state.parentSession = sourceSession;
+
+	let replacement: SessionManager;
+	try {
+		replacement = SessionManager.forkFrom(sourceSession, state.path);
+		const replacementFile = replacement.getSessionFile();
+		if (!replacementFile) throw new Error("replacement session has no file");
+		replacement.appendCustomEntry(WORKTREE_SESSION_ENTRY, state);
+		const result = await ctx.switchSession(replacementFile, {
+			withSession: async (next) => {
+				next.ui.notify(`Entered worktree: ${formatTargetLabel(state)}`, "info");
+			},
+		});
+		if (result.cancelled && state.created) {
+			removeWorktree(state);
+			fs.rmSync(replacementFile, { force: true });
+		}
+	} catch (error) {
+		if (state.created) removeWorktree(state);
+		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+	}
+}
+
+async function switchOutOfWorktree(ctx: ExtensionCommandContext): Promise<void> {
+	const state = readWorktreeSessionState(ctx);
+	if (!state) {
+		ctx.ui.notify("This session was not entered through EnterWorktree.", "warning");
+		return;
+	}
+	if (!fs.existsSync(state.parentSession)) {
+		ctx.ui.notify(`Parent session no longer exists: ${state.parentSession}`, "error");
+		return;
+	}
+
+	let remove = false;
+	if (state.created && ctx.hasUI) {
+		const dirty = worktreeHasChanges(state);
+		const options = dirty
+			? ["Keep worktree (changes detected)", "Remove worktree and branch anyway", "Cancel"]
+			: ["Keep worktree", "Remove worktree and branch", "Cancel"];
+		const choice = await ctx.ui.select(`Exit ${formatTargetLabel(state)}`, options);
+		if (!choice || choice === "Cancel") return;
+		remove = choice.startsWith("Remove ");
+	}
+
+	const result = await ctx.switchSession(state.parentSession, {
+		withSession: async (parent) => {
+			if (remove) {
+				const error = removeWorktree(state);
+				if (error) {
+					parent.ui.notify(`Returned to parent session, but cleanup failed: ${error}`, "warning");
+					return;
+				}
+				parent.ui.notify(`Exited worktree and removed: ${state.path}`, "info");
+				return;
+			}
+			parent.ui.notify(`Exited worktree; kept: ${state.path}`, "info");
+		},
+	});
+	if (result.cancelled) return;
+}
+
+interface EnterWorktreeToolInput {
+	name?: string;
+	path?: string;
+}
+
+interface TransitionMessageOptions {
+	deliverAs: "followUp";
+	expandPromptTemplates: true;
+}
+
+function queueTransitionCommand(
+	pi: Pick<ExtensionAPI, "sendUserMessage">,
+	command: string,
+): void {
+	const sendUserMessage = pi.sendUserMessage as (
+		content: string,
+		options: TransitionMessageOptions,
+	) => void;
+	sendUserMessage(command, {
+		deliverAs: "followUp",
+		expandPromptTemplates: true,
+	});
+}
+
+const enterWorktreeParameters = Type.Object({
+	name: Type.Optional(Type.String({ description: "New managed worktree name" })),
+	path: Type.Optional(Type.String({ description: "Existing registered worktree path" })),
+});
+
+export default function registerWorktreeSession(pi: ExtensionAPI): void {
+	pi.registerCommand("enter-worktree", {
+		description: "Create or enter a git worktree in a replacement Pi session",
+		handler: async (args, ctx) => {
+			let request: EnterWorktreeRequest;
+			try {
+				request = args.trim().startsWith("{") ? (JSON.parse(args) as EnterWorktreeRequest) : { name: args.trim() || undefined };
+			} catch {
+				ctx.ui.notify("Invalid EnterWorktree request JSON.", "error");
+				return;
+			}
+			await switchIntoWorktree(ctx, request);
+		},
+	});
+
+	pi.registerCommand("exit-worktree", {
+		description: "Return to the parent Pi session and optionally clean up its git worktree",
+		handler: async (_args, ctx) => {
+			await switchOutOfWorktree(ctx);
+		},
+	});
+
+	pi.registerTool({
+		name: "enter_worktree",
+		label: "Enter Worktree",
+		promptSnippet: "Switch the current Pi session into an isolated git worktree.",
+		description: "Queue a Pi session transition into a new or existing git worktree. The transition is applied by the enter-worktree command.",
+		renderShell: "self",
+		renderCall: () => new Text("", 0, 0),
+		renderResult(result, options, theme, context) {
+			const params = context.args as EnterWorktreeToolInput;
+			const target = params.name ?? params.path ?? "new worktree";
+			return renderWorktreeToolResult(result, options, theme, context, `enter ${safeDisplayText(target)}`);
+		},
+		parameters: enterWorktreeParameters,
+		async execute(_toolCallId, params: EnterWorktreeToolInput) {
+			queueTransitionCommand(
+				pi,
+				`/enter-worktree ${JSON.stringify(params)}`,
+			);
+			return {
+				content: [{ type: "text", text: "Queued enter_worktree; the session transition is pending." }],
+				details: { status: "queued", transition: "enter_worktree", request: params },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "exit_worktree",
+		label: "Exit Worktree",
+		promptSnippet: "Return the current Pi session to its parent session and handle worktree cleanup.",
+		description: "Queue a Pi session transition back to the parent session. Cleanup is selected by the user when the command runs.",
+		renderShell: "self",
+		renderCall: () => new Text("", 0, 0),
+		renderResult(result, options, theme, context) {
+			return renderWorktreeToolResult(result, options, theme, context, "exit current worktree");
+		},
+		parameters: Type.Object({}),
+		async execute() {
+			queueTransitionCommand(pi, "/exit-worktree");
+			return {
+				content: [{ type: "text", text: "Queued exit_worktree; the session transition is pending." }],
+				details: { status: "queued", transition: "exit_worktree" },
+			};
+		},
+	});
+}

--- a/packages/utils/features/worktree-completion.feature
+++ b/packages/utils/features/worktree-completion.feature
@@ -54,3 +54,9 @@ Feature: git worktree-aware @ completions
     Given a pi session running in a git repository
     When several completion rounds run in the same session
     Then the git worktree list command runs at most once
+
+  Scenario: Filtering follows session replacement into a worktree
+    Given a git repository with a linked worktree at .pi/worktrees/foo
+    And a pi session that started in the repository root
+    When the session is replaced into .pi/worktrees/foo and the provider suggests "../README.md"
+    Then the suggestion is dropped

--- a/packages/utils/features/worktree-completion.feature
+++ b/packages/utils/features/worktree-completion.feature
@@ -1,0 +1,56 @@
+Feature: git worktree-aware @ completions
+  The utils package filters editor file suggestions so a pi session only sees
+  paths that belong to its own git worktree. A session in main never suggests
+  linked worktree contents, and a session inside a linked worktree never
+  suggests sibling worktrees or the main checkout.
+
+  Background:
+    Given the pi-utils-fradser package is installed
+
+  Scenario: Main checkout hides linked worktree paths
+    Given a git repository with a linked worktree at wt-b
+    And a pi session running in the repository root
+    When the built-in provider suggests "../wt-b/src/index.ts"
+    Then the suggestion is dropped
+
+  Scenario: A linked worktree hides sibling worktrees and the main checkout
+    Given a git repository with linked worktrees at wt-b and wt-c
+    And a pi session running inside wt-b
+    When the built-in provider suggests "../../<main>/README.md" or "../wt-c/src/index.ts"
+    Then both suggestions are dropped
+
+  Scenario: Own worktree paths stay visible
+    Given a pi session running inside a linked worktree
+    When the built-in provider suggests "src/index.ts"
+    Then the suggestion is kept
+
+  Scenario: Quoted and @-prefixed values are filtered like plain paths
+    Given a session in main with a linked worktree at .pi/worktrees/foo
+    When the provider suggests '@".pi/worktrees/foo/src/index.ts"'
+    Then the suggestion is dropped
+
+  Scenario: Absolute candidate paths resolve before filtering
+    Given a pi session running inside a linked worktree
+    When the provider suggests an absolute path under the main checkout
+    Then the suggestion is dropped
+
+  Scenario: Directory entries of foreign roots are dropped too
+    Given a session in main with a linked worktree at .pi/worktrees/foo
+    When the provider suggests ".pi/worktrees/foo/"
+    Then the suggestion is dropped
+
+  Scenario: Non-git directories disable filtering
+    Given a session running outside any git repository
+    When the provider returns suggestions
+    Then every suggestion is kept unchanged
+
+  Scenario: A session opened in a bare repository filters its linked worktrees
+    Given a bare repository acting as the shared store for linked worktrees
+    And a pi session running at the bare repository path
+    When the provider suggests a path inside one of the linked worktrees
+    Then the suggestion is dropped
+
+  Scenario: Worktree discovery happens once per session
+    Given a pi session running in a git repository
+    When several completion rounds run in the same session
+    Then the git worktree list command runs at most once

--- a/packages/utils/features/worktree-session.feature
+++ b/packages/utils/features/worktree-session.feature
@@ -1,0 +1,66 @@
+Feature: EnterWorktree and ExitWorktree session switching
+  The utils package provides Claude Code-style worktree session switching.
+  EnterWorktree creates or selects a git worktree, forks the current session into
+  that worktree, and switches the Pi runtime to the worktree cwd. ExitWorktree
+  returns to the parent session and offers cleanup for worktrees created by Pi.
+
+  Background:
+    Given the pi-utils-fradser package is installed
+
+  Scenario: EnterWorktree creates a managed worktree and replacement session
+    Given a persisted Pi session in the repository root
+    When EnterWorktree is called with the name "feature-auth"
+    Then a worktree is created at ".pi/worktrees/feature-auth"
+    And a branch named "pi/worktree/feature-auth" is created
+    And the replacement session cwd is the new worktree root
+    And the replacement session records the original session as its parent
+
+  Scenario: EnterWorktree enters an existing worktree without recreating it
+    Given a persisted Pi session and an existing registered git worktree
+    When EnterWorktree is called with that worktree path
+    Then no new worktree or branch is created
+    And the replacement session cwd is the existing worktree root
+
+  Scenario: EnterWorktree switches directly between worktrees
+    Given a Pi session already inside worktree A
+    When EnterWorktree is called for worktree B
+    Then the replacement session cwd is worktree B
+    And ExitWorktree returns to worktree A before the original parent session
+
+  Scenario: ExitWorktree returns to the parent session
+    Given a Pi session entered through EnterWorktree
+    When ExitWorktree is called and the worktree is kept
+    Then Pi switches to the parent session
+    And the worktree remains on disk
+
+  Scenario: ExitWorktree can remove a clean worktree created by Pi
+    Given a Pi session in a clean worktree created by EnterWorktree
+    When the user chooses to remove the worktree during ExitWorktree
+    Then the worktree and its Pi-created branch are removed
+    And Pi switches to the parent session
+
+  Scenario: ExitWorktree preserves dirty work by default
+    Given a Pi session in a worktree with uncommitted changes
+    When ExitWorktree is called and the user chooses to keep the worktree
+    Then the worktree and its changes remain on disk
+    And Pi switches to the parent session
+
+  Scenario: EnterWorktree rejects an unregistered existing path
+    Given a persisted Pi session in a git repository
+    When EnterWorktree is called with a path that is not a registered git worktree
+    Then the operation fails without creating a session or deleting files
+
+  Scenario: EnterWorktree and ExitWorktree tools queue their session commands
+    Given the Pi extension is loaded
+    When the model calls EnterWorktree or ExitWorktree
+    Then the tool queues the corresponding user command
+    And the tool result reports that the transition is queued rather than complete
+
+  Scenario: Worktree transition tools render compact started lifecycle rows
+    Given the Pi extension is loaded in TUI mode
+    When the model calls EnterWorktree or ExitWorktree
+    Then each tool owns its shell rendering with an empty call row
+    And each tool result renders one pi-kit worktree event row
+    And the EnterWorktree row is `[worktree] enter · feature-auth`
+    And the ExitWorktree row is `[worktree] exit · current worktree`
+    And the row does not claim that the session transition is complete

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -4,11 +4,15 @@ import registerEffort from "./extensions/effort.ts";
 import registerInit from "./extensions/init.ts";
 import registerSessions from "./extensions/sessions.ts";
 import registerWorktree from "./extensions/worktree.ts";
+import registerWorktreeCompletion from "./extensions/worktree-completion.ts";
+import registerWorktreeSession from "./extensions/worktree-session.ts";
 
 export default function utilsExtension(pi: ExtensionAPI): void {
-  registerContinue(pi);
-  registerEffort(pi);
-  registerInit(pi);
-  registerSessions(pi);
-  registerWorktree(pi);
+	registerContinue(pi);
+	registerEffort(pi);
+	registerInit(pi);
+	registerSessions(pi);
+	registerWorktree(pi);
+	registerWorktreeCompletion(pi);
+	registerWorktreeSession(pi);
 }

--- a/packages/utils/tests/test_worktree_completion.py
+++ b/packages/utils/tests/test_worktree_completion.py
@@ -223,6 +223,44 @@ console.log(JSON.stringify({{
         self.assertTrue(report["applyDelegates"])
         self.assertTrue(report["triggerDelegates"])
 
+    def test_filtering_follows_session_replacement_cwd(self) -> None:
+        script = f"""
+import registerWorktreeCompletion from {json.dumps(COMPLETION_EXTENSION.as_uri())};
+const handlers = new Map();
+let factory = null;
+const pi = {{ on: (event, handler) => handlers.set(event, handler) }};
+const makeCtx = (cwd) => ({{
+  cwd,
+  ui: {{ addAutocompleteProvider: (f) => {{ factory = f; }} }},
+}});
+registerWorktreeCompletion(pi);
+handlers.get("session_start")({{}}, makeCtx({json.dumps(str(self.main))}));
+const current = {{ async getSuggestions() {{ return {{ items: [{{ value: "../main-repo/README.md" }}, {{ value: "src/index.ts" }}] }}; }} }};
+const provider = factory(current);
+const before = await provider.getSuggestions([], 0, 0, {{}});
+handlers.get("session_start")({{}}, makeCtx({json.dumps(str(self.wt_b))}));
+const after = await provider.getSuggestions([], 0, 0, {{}});
+console.log(JSON.stringify({{
+  beforeKeptMainReadme: before.items.some((item) => item.value === "../main-repo/README.md"),
+  afterDropsMainReadme: !after.items.some((item) => item.value === "../main-repo/README.md"),
+  afterKeepsOwnSrc: after.items.some((item) => item.value === "src/index.ts"),
+}}));
+"""
+        result = subprocess.run(
+            ["node", "--input-type=module"],
+            cwd=REPO,
+            input=script,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode:
+            raise AssertionError(f"Node runner failed:\n{result.stderr}")
+        report = json.loads(result.stdout)
+        self.assertTrue(report["beforeKeptMainReadme"])
+        self.assertTrue(report["afterDropsMainReadme"])
+        self.assertTrue(report["afterKeepsOwnSrc"])
+
     def test_discovery_runs_git_once_across_repeated_rounds(self) -> None:
         counter_bin = Path(tempfile.mkdtemp(prefix="pi-wtc-bin-"))
         counter = counter_bin / "count"

--- a/packages/utils/tests/test_worktree_completion.py
+++ b/packages/utils/tests/test_worktree_completion.py
@@ -1,0 +1,263 @@
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+UTILS_PKG_DIR = Path(__file__).resolve().parents[1]
+REPO = UTILS_PKG_DIR.parents[1]
+COMPLETION_EXTENSION = UTILS_PKG_DIR / "extensions" / "worktree-completion.ts"
+
+
+def run_ts(script: str) -> object:
+    result = subprocess.run(
+        ["bun", "run", "-"],
+        cwd=REPO,
+        input=script,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise AssertionError(f"TypeScript runner failed:\n{result.stderr}")
+    return json.loads(result.stdout)
+
+
+GIT = shutil.which("git")
+
+
+def make_git_repo(path: Path) -> None:
+    def git(*args: str, cwd: Path | None = None) -> None:
+        subprocess.run(["git", *args], cwd=cwd or path,
+                       capture_output=True, text=True, check=True)
+
+    git("init", "-q")
+    git("config", "user.name", "t")
+    git("config", "user.email", "t@t")
+    (path / "src").mkdir()
+    (path / "README.md").write_text("main readme\n")
+    (path / "src" / "index.ts").write_text("export {};\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+
+class WorktreeCompletionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.base = Path(tempfile.mkdtemp(prefix="pi-wtc-")).resolve()
+        self.main = self.base / "main-repo"
+        self.main.mkdir()
+        make_git_repo(self.main)
+        self.wt_b = self.base / "wt-b"
+        self.wt_c = self.base / "wt-c"
+        for name in ("b", "c"):
+            subprocess.run(["git", "worktree", "add", f"{self.base}/wt-{name}", "-b", name],
+                           cwd=self.main, capture_output=True, text=True, check=True)
+
+    def is_foreign(self, value: str, cwd: Path) -> bool:
+        script = f"""
+import {{ collectWorktreeRoots, isInForeignWorktree }} from {json.dumps(COMPLETION_EXTENSION.as_uri())};
+const roots = collectWorktreeRoots({json.dumps(str(cwd))});
+console.log(JSON.stringify(isInForeignWorktree({json.dumps(value)}, {json.dumps(str(cwd))}, roots)));
+"""
+        return bool(run_ts(script))
+
+    def test_main_checkout_collects_linked_worktrees_as_foreign(self) -> None:
+        result = run_ts(f"""
+import fs from "node:fs";
+import {{ collectWorktreeRoots }} from {json.dumps(COMPLETION_EXTENSION.as_uri())};
+const roots = collectWorktreeRoots({json.dumps(str(self.main))});
+console.log(JSON.stringify({{
+  currentIsMain: roots.currentRoot === fs.realpathSync({json.dumps(str(self.main))}),
+  foreignCount: roots.foreignRoots.length,
+}}));
+""")
+        self.assertTrue(result["currentIsMain"])
+        self.assertEqual(2, result["foreignCount"])
+
+    def test_worktree_sees_siblings_and_main_as_foreign(self) -> None:
+        result = run_ts(f"""
+import fs from "node:fs";
+import {{ collectWorktreeRoots }} from {json.dumps(COMPLETION_EXTENSION.as_uri())};
+const roots = collectWorktreeRoots({json.dumps(str(self.wt_b))});
+const foreign = new Set(roots.foreignRoots);
+console.log(JSON.stringify({{
+  hasMain: foreign.has(fs.realpathSync({json.dumps(str(self.main))})),
+  hasSibling: foreign.has(fs.realpathSync({json.dumps(str(self.wt_c))})),
+  currentSelf: roots.currentRoot === fs.realpathSync({json.dumps(str(self.wt_b))}),
+}}));
+""")
+        self.assertTrue(result["hasMain"])
+        self.assertTrue(result["hasSibling"])
+        self.assertTrue(result["currentSelf"])
+
+    def test_non_git_directory_disables_filtering(self) -> None:
+        outside = Path(tempfile.mkdtemp(prefix="pi-wtc-nogit-"))
+        self.assertFalse(self.is_foreign("../anything/x.ts", outside))
+
+    def test_main_hides_sibling_worktree_paths(self) -> None:
+        self.assertTrue(self.is_foreign("../wt-b/src/index.ts", self.main))
+        self.assertTrue(self.is_foreign("../wt-b/", self.main))
+        self.assertFalse(self.is_foreign("src/index.ts", self.main))
+        self.assertFalse(self.is_foreign("README.md", self.main))
+
+    def test_nonexistent_leaf_under_symlinked_base_is_still_foreign(self) -> None:
+        # macOS /var-style symlinks: realpath fails on missing leaves, but the
+        # candidate must still resolve into the canonical worktree space.
+        self.assertTrue(self.is_foreign("../wt-b/dir with space/x.ts", self.main))
+        self.assertTrue(self.is_foreign(str(self.wt_b / "nope" / "x.ts"), self.main))
+
+    def test_symlinked_base_fixture_resolves_before_filtering(self) -> None:
+        # Deterministic cross-platform version of the ambient-symlink case: a
+        # symlinked session path must not hide foreign roots behind it.
+        linked = self.base.parent / "linked"
+        os.symlink(self.base, linked, target_is_directory=True)
+        try:
+            via_link = linked / "main-repo"
+            self.assertTrue(self.is_foreign("../wt-b/nope/x.ts", via_link))
+            self.assertFalse(self.is_foreign("src/index.ts", via_link))
+        finally:
+            os.remove(linked)
+
+    def test_nested_pi_worktrees_path_is_foreign_from_main(self) -> None:
+        subprocess.run(["git", "worktree", "add", ".pi/worktrees/foo", "-b", "foo"],
+                       cwd=self.main, capture_output=True, text=True, check=True)
+        self.assertTrue(self.is_foreign(".pi/worktrees/foo/src/index.ts", self.main))
+        self.assertTrue(self.is_foreign('@".pi/worktrees/foo/src/index.ts"', self.main))
+        self.assertTrue(self.is_foreign(".pi/worktrees/foo/", self.main))
+        self.assertFalse(self.is_foreign(".pi/worktrees", self.main))
+
+    def test_worktree_hides_main_and_siblings(self) -> None:
+        self.assertTrue(self.is_foreign("../main-repo/README.md", self.wt_b))
+        self.assertTrue(self.is_foreign("../wt-c/src/index.ts", self.wt_b))
+        self.assertFalse(self.is_foreign("src/index.ts", self.wt_b))
+
+    def test_absolute_and_home_relative_candidates_resolve_before_filtering(self) -> None:
+        absolute = str(self.main / "src" / "index.ts")
+        self.assertTrue(self.is_foreign(absolute, self.wt_b))
+        self.assertFalse(self.is_foreign("~/outside-any-repo/file.ts", self.wt_b))
+
+    def test_filter_drops_only_foreign_items_in_order(self) -> None:
+        script = f"""
+import {{ collectWorktreeRoots, filterForeignWorktreeItems }} from {json.dumps(COMPLETION_EXTENSION.as_uri())};
+const roots = collectWorktreeRoots({json.dumps(str(self.main))});
+const items = [
+  {{ value: "src/index.ts", label: "index.ts" }},
+  {{ value: "../wt-b/src/index.ts", label: "index.ts", description: "../wt-b/src/index.ts" }},
+  {{ value: "../wt-c/", label: "wt-c/" }},
+];
+console.log(JSON.stringify(filterForeignWorktreeItems(items, {json.dumps(str(self.main))}, roots)));
+"""
+        result = run_ts(script)
+        self.assertEqual(["src/index.ts"], [item["value"] for item in result])
+
+    def test_bare_repository_session_filters_linked_worktrees(self) -> None:
+        source = self.base / "bare-source"
+        source.mkdir()
+        make_git_repo(source)
+        bare = self.base / "store.git"
+        subprocess.run(["git", "clone", "--bare", str(source), str(bare)],
+                       capture_output=True, text=True, check=True)
+        wt_w = self.base / "wt-w"
+        subprocess.run(["git", "worktree", "add", str(wt_w), "-b", "w"],
+                       cwd=bare, capture_output=True, text=True, check=True)
+
+        self.assertTrue(self.is_foreign(str(wt_w / "anything.ts"), bare))
+        self.assertFalse(self.is_foreign("config", bare))
+
+    def test_extension_registration_filters_and_delegates(self) -> None:
+        script = f"""
+process.env.PATH = "/nonexistent-shim:" + process.env.PATH;
+import registerWorktreeCompletion from {json.dumps(COMPLETION_EXTENSION.as_uri())};
+let handler = null;
+registerWorktreeCompletion({{ on: (_e, h) => {{ handler = h; }} }});
+if (!handler) throw new Error("session_start handler was not registered");
+
+let factory = null;
+const ctx = {{
+  cwd: {json.dumps(str(self.main))},
+  ui: {{ addAutocompleteProvider: (f) => {{ factory = f; }} }},
+}};
+handler({{}}, ctx);
+if (!factory) throw new Error("autocomplete provider factory was not registered");
+
+const current = {{
+  async getSuggestions() {{
+    return {{
+      prefix: "@x",
+      items: [
+        {{ value: "@README.md", label: "README.md" }},
+        {{ value: "@../wt-b/src/index.ts", label: "index.ts" }},
+      ],
+    }};
+  }},
+  applyCompletion(...args) {{ return args; }},
+  shouldTriggerFileCompletion() {{ return "delegated"; }},
+}};
+const wrapped = factory(current);
+const options = {{ signal: new AbortController().signal }};
+const first = await wrapped.getSuggestions(["@x"], 0, 3, options);
+const second = await wrapped.getSuggestions(["@x"], 0, 3, options);
+console.log(JSON.stringify({{
+  firstValues: first.items.map((i) => i.value),
+  secondValues: second.items.map((i) => i.value),
+  applyDelegates: JSON.stringify(wrapped.applyCompletion("L", 0, 1, {{}}, "@")) === JSON.stringify(["L", 0, 1, {{}}, "@"]),
+  triggerDelegates: wrapped.shouldTriggerFileCompletion([], 0, 0) === "delegated",
+}}));
+"""
+        result = subprocess.run(
+            ["node", "--input-type=module"],
+            cwd=REPO,
+            input=script,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode:
+            raise AssertionError(f"Node runner failed:\n{result.stderr}")
+        report = json.loads(result.stdout)
+        self.assertEqual(["@README.md"], report["firstValues"])
+        self.assertEqual(["@README.md"], report["secondValues"])
+        self.assertTrue(report["applyDelegates"])
+        self.assertTrue(report["triggerDelegates"])
+
+    def test_discovery_runs_git_once_across_repeated_rounds(self) -> None:
+        counter_bin = Path(tempfile.mkdtemp(prefix="pi-wtc-bin-"))
+        counter = counter_bin / "count"
+        counter.write_text("0\n")
+        shim = counter_bin / "git"
+        shim.write_text(
+            "#!/bin/sh\n"
+            f'echo $(($(cat "{counter}") + 1)) > "{counter}"\n'
+            f'exec {json.dumps(GIT)} "$@"\n'
+        )
+        shim.chmod(shim.stat().st_mode | stat.S_IEXEC)
+
+        script = f"""
+process.env.PATH = {json.dumps(str(counter_bin))} + ":" + process.env.PATH;
+const mod = await import({json.dumps(COMPLETION_EXTENSION.as_uri())});
+const first = mod.getWorktreeRoots({json.dumps(str(self.main))});
+const second = mod.getWorktreeRoots({json.dumps(str(self.main))});
+console.log(JSON.stringify({{ sameRef: first === second }}));
+"""
+        # Bun snapshots PATH for child-process lookup, but pi runs on Node,
+        # which re-resolves per spawn — run this scenario through node.
+        result = subprocess.run(
+            ["node", "--input-type=module"],
+            cwd=REPO,
+            input=script,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode:
+            raise AssertionError(f"Node runner failed:\n{result.stderr}")
+        self.assertTrue(json.loads(result.stdout)["sameRef"])
+        # One discovery = exactly two spawns (worktree list + rev-parse).
+        self.assertEqual(2, int(counter.read_text()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/utils/tests/test_worktree_session.py
+++ b/packages/utils/tests/test_worktree_session.py
@@ -1,0 +1,242 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+UTILS_PKG_DIR = Path(__file__).resolve().parents[1]
+REPO = UTILS_PKG_DIR.parents[1]
+SESSION_EXTENSION = UTILS_PKG_DIR / "extensions" / "worktree-session.ts"
+
+
+def run_ts(script: str) -> dict:
+    result = subprocess.run(
+        ["bun", "run", "-"],
+        cwd=REPO,
+        input=script,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise AssertionError(f"TypeScript runner failed:\n{result.stderr}")
+    return json.loads(result.stdout)
+
+
+def make_git_repo(path: Path) -> None:
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=path, capture_output=True, text=True, check=True)
+
+    git("init", "-q")
+    git("config", "user.name", "t")
+    git("config", "user.email", "t@t")
+    (path / "README.md").write_text("main\n")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+
+class WorktreeSessionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.base = Path(tempfile.mkdtemp(prefix="pi-wts-")).resolve()
+        self.repo = self.base / "repo"
+        self.repo.mkdir()
+        self.session_dir = self.base / "sessions"
+        self.session_dir.mkdir()
+        make_git_repo(self.repo)
+
+    def test_parse_worktree_list_preserves_bare_and_branch_metadata(self) -> None:
+        result = run_ts(f"""
+import {{ parseWorktreeList }} from {json.dumps(SESSION_EXTENSION.as_uri())};
+console.log(JSON.stringify(parseWorktreeList([
+  "worktree /tmp/main",
+  "HEAD abc",
+  "branch refs/heads/main",
+  "",
+  "worktree /tmp/feature",
+  "HEAD def",
+  "branch refs/heads/feature",
+  "",
+  "worktree /tmp/store.git",
+  "bare",
+].join("\\n"))));
+""")
+        self.assertEqual(
+            [
+                {"bare": False, "branch": "main", "root": "/tmp/main"},
+                {"bare": False, "branch": "feature", "root": "/tmp/feature"},
+                {"bare": True, "root": "/tmp/store.git"},
+            ],
+            result,
+        )
+
+    def test_resolve_enter_target_creates_managed_path_and_rejects_unregistered_path(self) -> None:
+        result = run_ts(f"""
+import {{ resolveEnterTarget }} from {json.dumps(SESSION_EXTENSION.as_uri())};
+const created = resolveEnterTarget({json.dumps(str(self.repo))}, {{ name: "feature/auth" }});
+const rejected = resolveEnterTarget({json.dumps(str(self.repo))}, {{ path: "../not-a-worktree" }});
+console.log(JSON.stringify({{ created, rejected }}));
+""")
+        self.assertTrue(result["created"]["created"])
+        self.assertEqual("feature-auth", result["created"]["name"])
+        self.assertTrue(result["created"]["path"].endswith("/.pi/worktrees/feature-auth"))
+        self.assertIn("not a registered git worktree", result["rejected"]["error"])
+
+    def test_new_worktree_path_is_shared_when_entering_from_an_existing_worktree(self) -> None:
+        nested = self.base / "existing"
+        subprocess.run(["git", "worktree", "add", str(nested), "-b", "existing"],
+                       cwd=self.repo, capture_output=True, text=True, check=True)
+        result = run_ts(f"""
+import {{ resolveEnterTarget }} from {json.dumps(SESSION_EXTENSION.as_uri())};
+console.log(JSON.stringify(resolveEnterTarget({json.dumps(str(nested))}, {{ name: "next" }})));
+""")
+        self.assertTrue(result["created"])
+        self.assertTrue(result["path"].startswith(str(self.repo / ".pi" / "worktrees")))
+        self.assertFalse(result["path"].startswith(str(nested / ".pi")))
+
+    def test_enter_command_creates_worktree_forks_session_and_records_parent(self) -> None:
+        script = f"""
+import fs from "node:fs";
+import {{ SessionManager }} from "@earendil-works/pi-coding-agent";
+import registerWorktreeSession from {json.dumps(SESSION_EXTENSION.as_uri())};
+
+const repo = {json.dumps(str(self.repo))};
+const source = SessionManager.create(repo, {json.dumps(str(self.session_dir))});
+source.appendMessage({{ role: "user", content: "start", timestamp: Date.now() }});
+source.appendMessage({{ role: "assistant", content: [{{ type: "text", text: "ready" }}], api: "test", provider: "test", model: "test", usage: {{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: {{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }} }}, stopReason: "stop", timestamp: Date.now() }});
+const sourceFile = source.getSessionFile();
+let commands = {{}};
+const fakePi = {{
+  registerCommand(name, options) {{ commands[name] = options; }},
+  registerTool() {{}},
+  sendUserMessage() {{}},
+}};
+registerWorktreeSession(fakePi);
+let switchedFile = null;
+const notifications = [];
+const ctx = {{
+  cwd: repo,
+  hasUI: true,
+  sessionManager: {{ getSessionFile: () => sourceFile, getBranch: () => [] }},
+  ui: {{
+    notify(message, type) {{ notifications.push({{ message, type }}); }},
+    select: async () => "Keep worktree",
+  }},
+  async switchSession(file, options) {{
+    switchedFile = file;
+    await options.withSession({{ ui: {{ notify() {{}} }} }});
+    return {{ cancelled: false }};
+  }},
+}};
+await commands["enter-worktree"].handler("feature-auth", ctx);
+const replacement = SessionManager.open(switchedFile);
+const header = replacement.getHeader();
+const entries = replacement.getBranch();
+const state = entries.find((entry) => entry.type === "custom" && entry.customType === "pi-utils-worktree-session");
+console.log(JSON.stringify({{
+  switchedFile,
+  cwd: header.cwd,
+  parentSession: header.parentSession,
+  state: state.data,
+  worktreeExists: fs.existsSync(header.cwd),
+  branch: state.data.branch,
+  notifications,
+}}));
+"""
+        result = run_ts(script)
+        self.assertTrue(result["worktreeExists"])
+        self.assertTrue(result["cwd"].endswith("/.pi/worktrees/feature-auth"))
+        self.assertEqual(result["parentSession"], result["state"]["parentSession"])
+        self.assertEqual("pi/worktree/feature-auth", result["branch"])
+        self.assertEqual([], result["notifications"])
+
+        subprocess.run(
+            ["git", "-C", str(self.repo), "worktree", "remove", "--force", result["cwd"]],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(self.repo), "branch", "-D", result["branch"]],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def test_tools_queue_transitions_instead_of_claiming_completion(self) -> None:
+        script = f"""
+import registerWorktreeSession from {json.dumps(SESSION_EXTENSION.as_uri())};
+const tools = {{}};
+const sent = [];
+const fakePi = {{
+  registerCommand() {{}},
+  registerTool(tool) {{ tools[tool.name] = tool; }},
+  sendUserMessage(message, options) {{ sent.push({{ message, options }}); }},
+}};
+registerWorktreeSession(fakePi);
+const enter = await tools.enter_worktree.execute("1", {{ name: "feature-auth" }});
+const exit = await tools.exit_worktree.execute("2", {{}});
+const theme = {{ fg: (_color, text) => text, bold: (text) => text }};
+const enterRow = tools.enter_worktree.renderResult(
+  enter,
+  {{ expanded: false, isPartial: false }},
+  theme,
+  {{ args: {{ name: "feature-auth" }}, isError: false }},
+).render(120).join("\\n");
+const exitRow = tools.exit_worktree.renderResult(
+  exit,
+  {{ expanded: false, isPartial: false }},
+  theme,
+  {{ args: {{}}, isError: false }},
+).render(120).join("\\n");
+console.log(JSON.stringify({{ sent, enter, exit, enterRow, exitRow }}));
+"""
+        result = run_ts(script)
+        self.assertEqual("/enter-worktree {\"name\":\"feature-auth\"}", result["sent"][0]["message"])
+        self.assertTrue(result["sent"][0]["options"]["expandPromptTemplates"])
+        self.assertEqual("/exit-worktree", result["sent"][1]["message"])
+        self.assertTrue(result["sent"][1]["options"]["expandPromptTemplates"])
+        self.assertEqual("queued", result["enter"]["details"]["status"])
+        self.assertEqual("queued", result["exit"]["details"]["status"])
+        self.assertEqual("[worktree] enter · feature-auth", result["enterRow"])
+        self.assertEqual("[worktree] exit · current worktree", result["exitRow"])
+
+    def test_exit_command_switches_to_parent_and_can_keep_worktree(self) -> None:
+        script = f"""
+import fs from "node:fs";
+import {{ SessionManager }} from "@earendil-works/pi-coding-agent";
+import registerWorktreeSession from {json.dumps(SESSION_EXTENSION.as_uri())};
+const repo = {json.dumps(str(self.repo))};
+const source = SessionManager.create(repo, {json.dumps(str(self.session_dir))});
+source.appendMessage({{ role: "user", content: "start", timestamp: Date.now() }});
+source.appendMessage({{ role: "assistant", content: [{{ type: "text", text: "ready" }}], api: "test", provider: "test", model: "test", usage: {{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: {{ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }} }}, stopReason: "stop", timestamp: Date.now() }});
+const sourceFile = source.getSessionFile();
+fs.mkdirSync({json.dumps(str(self.base / ".pi" / "worktrees" / "kept"))}, {{ recursive: true }});
+const target = SessionManager.forkFrom(sourceFile, {json.dumps(str(self.base / ".pi" / "worktrees" / "kept"))});
+const targetFile = target.getSessionFile();
+target.appendCustomEntry("pi-utils-worktree-session", {{
+  baseCommit: "HEAD", created: false, parentSession: sourceFile,
+  path: {json.dumps(str(self.base / ".pi" / "worktrees" / "kept"))},
+  repoRoot: repo,
+}});
+let commands = {{}};
+let switched = null;
+const fakePi = {{ registerCommand(name, options) {{ commands[name] = options; }}, registerTool() {{}}, sendUserMessage() {{}} }};
+registerWorktreeSession(fakePi);
+const ctx = {{
+  cwd: {json.dumps(str(self.base / ".pi" / "worktrees" / "kept"))},
+  hasUI: false,
+  sessionManager: SessionManager.open(targetFile),
+  ui: {{ notify() {{}} }},
+  async switchSession(file) {{ switched = file; return {{ cancelled: false }}; }},
+}};
+await commands["exit-worktree"].handler("", ctx);
+console.log(JSON.stringify({{ switched, sourceFile, exists: fs.existsSync(ctx.cwd) }}));
+"""
+        result = run_ts(script)
+        self.assertEqual(result["sourceFile"], result["switched"])
+        self.assertTrue(result["exists"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Two related worktree-isolation features for `@fradser/pi-utils`:

**EnterWorktree / ExitWorktree session switching**
- Pi cannot mutate a running session's cwd in place, so switching uses Pi's session replacement API: built-in `read`/`edit`/`bash` and @ tools all rebind to the worktree cwd
- `/enter-worktree <name>` creates a managed worktree at `.pi/worktrees/<name>` on a `pi/worktree/<name>` branch; `/enter-worktree {"path": ...}` enters an existing registered worktree; `/exit-worktree` returns to the parent session with optional cleanup of Pi-created worktrees
- LLM-facing `enter_worktree`/`exit_worktree` tools queue the commands and report queued semantics honestly; TUI uses pi-kit lifecycle rows

**Worktree-aware @ completions**
- Editor file suggestions filtered to the session's own worktree via `git worktree list --porcelain`: main never sees linked worktrees, linked never sees siblings or the main checkout; no-op outside git repos

## Affected packages
- `@fradser/pi-utils` (minor ×2 changesets: pi-utils-enter-worktree, utils-worktree-aware-completions)

## Verification
- `python3 -m pytest packages/utils/tests -q`
- BDD contracts: features/worktree-session.feature, features/worktree-completion.feature

## Release impact
2 minor changesets included.

## README changes
packages/utils/README.md + AGENTS.md document both features.