### PR TITLE
feat(utils): npm publish/credential guard + npm-package-first-release skill

### DIFF
--- a/.agents/skills/npm-package-first-release/SKILL.md
+++ b/.agents/skills/npm-package-first-release/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: npm-package-first-release
+description: Bootstrap the first publication of an npm package and wire up Trusted Publishing (GitHub OIDC) in a monorepo. Use whenever a new package must be published to npm for the first time, when configuring npm trust github or a trusted publisher, when handing a package over from manual releases to CI-owned releases, or when diagnosing first-release failures such as EOTP, PUT 404, EPUBLISHCONFLICT, 401 on whoami, or "Package not found" during trust setup.
+---
+
+# npm package first release
+
+npm OIDC Trusted Publishing cannot create the **first** version of a package
+that does not exist yet, and a trust relationship cannot be created for a
+package that does not exist. The first version therefore needs one deliberate,
+human-in-the-loop publication; every later version is owned by CI. This skill
+walks that bootstrap and hands off cleanly.
+
+## Hard rules
+
+- Never ask the user to paste an OTP code into chat, and never automate
+  `npm login`, browser approval, or OTP entry. Interactive steps belong to the
+  user's own terminal, where prompts and browsers are visible to them.
+- Publish **before** configuring trust. `npm trust github` on an unpublished
+  package fails with `404 Package not found` — that error means ordering, not
+  a missing name.
+- In pnpm workspaces always publish with `pnpm publish`. It rewrites
+  `workspace:*` dependencies to real versions; plain `npm publish` would ship
+  an unresolvable manifest.
+- Do not run recursive root-level publishes (`pnpm -r publish`). Publish one
+  package from its directory.
+
+## Procedure
+
+### 0. Preconditions
+
+- The package name is on the repository's release allowlist (for pi-packages:
+  `scripts/publish-release.mjs`), so CI can take over after handoff.
+- Version/changeset coordination is decided: either a pending changeset will
+  produce a version PR, or the manifest version is already the exact version
+  intended for first publication. The registry-aware CI publisher skips
+  versions equal to what is on npm, so publishing an exact version early is
+  safe.
+
+### 1. Check credentials before anything else
+
+```bash
+npm whoami
+```
+
+- Success: continue.
+- `E401`: the stored token is dead. npm actively retires bypass-2FA tokens, so
+  tokens die silently even days after login. Ask the user to run `npm login`
+  themselves and confirm when done. Do not proceed on a dead token.
+
+A dead token is also why a publish of a brand-new package can fail with
+`PUT ... 404 Not Found`: the registry masks authorization failures for
+nonexistent packages as 404 instead of 401/403. When you see 404 on PUT,
+check `npm whoami` first before suspecting the package name.
+
+### 2. Check registry state
+
+```bash
+curl -s https://registry.npmjs.org/<package-name>
+```
+
+- 404: name is free — full bootstrap below.
+- HTTP 200 with no versions/dist-tags: the name was unpublished once
+  (tombstone); it can still be published after the 24-hour window.
+- Existing versions: this is not a first release — stop and reassess.
+
+### 3. User publishes the first version (interactive)
+
+The user runs, from the package directory:
+
+```bash
+pnpm publish --access public
+```
+
+pnpm prompts `Enter OTP:` inline; they type their authenticator code. If the
+branch is not the configured publish branch, pnpm asks to continue — answering
+yes is expected on wip/release branches.
+
+If the user must publish the exact version a changesets version PR produces,
+check out that PR's branch and publish from there, then merge it; the CI
+publisher compares local vs registry versions and skips what already exists.
+
+### 4. Establish the trust relationship
+
+Still the user's terminal:
+
+```bash
+npm trust github <package-name> --file <release-workflow>.yml \
+  --repo <owner>/<repo> --allow-publish -y
+```
+
+For pi-packages: `--file release.yml --repo FradSer/pi-packages`. This prints
+an auth URL and waits ("Press ENTER to open in the browser..."); the user
+approves in their browser. Requires npm >= 11.5.
+
+If this fails with `Package not found`, step 3 has not actually completed —
+verify the registry before retrying.
+
+### 5. Hand off to CI
+
+Merge the feature/version PR. The release workflow's registry-aware publisher
+sees the published version and skips it; all subsequent versions publish via
+GitHub Actions OIDC with provenance — no local token involved ever again.
+
+### 6. Verify
+
+```bash
+curl -s https://registry.npmjs.org/<package-name> | jq '."dist-tags".latest'
+```
+
+Registry edge caches can lag briefly after publish.
+
+## Failure quick table
+
+| Symptom | Real cause | Fix |
+| --- | --- | --- |
+| `PUT ... 404 Not Found` on a new package | Dead token masked by the registry | `npm whoami`; if E401, user re-runs `npm login` |
+| `EOTP` exiting immediately under automation | Non-TTY clients cannot complete web-auth | Stop automating; user runs the publish interactively |
+| Trust setup: `Package not found` | Package not published yet | Complete step 3 first, then re-run trust |
+| `EPUBLISHCONFLICT` / version exists | Version already on npm | Advance the version; never overwrite |
+| Token dies again days later | npm retiring bypass-2FA tokens | Re-login; prefer granular tokens with read-write packages |
+
+## Related project memory
+
+- `project_pi_package_npm_publishing` — allowlist + version-PR coordination.
+- `github-ci-npm-publishing` (pi-git-agent) — CI-only releases, `npm trust` CLI.
+- `npm-trusted-publishing` (apple-events) — trust requires existing package.

--- a/.changeset/utils-npm-publish-guard.md
+++ b/.changeset/utils-npm-publish-guard.md
@@ -1,0 +1,5 @@
+---
+"@fradser/pi-utils": minor
+---
+
+Block package publish and npm credential commands (`publish`, `login`/`adduser`/`logout`, `token create/revoke/delete`) from the agent's non-interactive bash tool. These flows cannot complete there — 2FA web-auth exits immediately with EOTP and dead tokens surface as masked 404 PUT failures — so the guard blocks the call and returns corrective steering that routes the interactive step to the user's own terminal and the `npm-package-first-release` skill procedure.

--- a/packages/utils/extensions/npm-publish-guard.ts
+++ b/packages/utils/extensions/npm-publish-guard.ts
@@ -20,7 +20,7 @@ const END = "(?:[;&|\\s]|$)";
 
 /** Workspace/filter flags package managers accept before the verb. */
 const PRE_FLAGS =
-	"(?:(?:--filter|--workspace|--since|-F|-w)(?:=[^\\s;&|]+|\\s+[^\\s;&|]+)?\\s+|workspace\\s+[^\\s;&|]+\\s+|-r\\s+|--recursive\\s+)*";
+	"(?:(?:--filter|--workspace|--since|-F|-w)(?:=[^\\s;&|]+|\\s+[^\\s;&|]+)?\\s+|(?:workspace\\s+[^\\s;&|]+|recursive)\\s+|-r\\s+|--recursive\\s+)*";
 
 interface GuardRule {
 	label: string;
@@ -30,9 +30,10 @@ interface GuardRule {
 const RULES: GuardRule[] = [
 	{
 		// Direct publish plus recursive/workspace forms (`pnpm -r publish`,
-		// `pnpm --filter web publish`, `yarn workspace web publish`).
+		// `pnpm --filter web publish`, `yarn workspace web publish`). Capture
+		// group 1 ends at the verb so the dry-run scan can start there.
 		label: "Package publish",
-		re: new RegExp(`${COMMAND_POS}(?:npm|pnpm|yarn|bun)\\s+${PRE_FLAGS}publish${END}`),
+		re: new RegExp(`${COMMAND_POS}((?:npm|pnpm|yarn|bun)\\s+${PRE_FLAGS})publish${END}`),
 	},
 	{
 		label: "npm credential flow",
@@ -48,15 +49,32 @@ export interface BlockedNpmCommand {
 	label: string;
 }
 
+/** True when the first command segment after the verb carries a real `--dry-run` token. */
+function invocationHasDryRunFlag(segment: string): boolean {
+	for (const token of (segment.split(/[;&|\n]/)[0] ?? "").split(/\s+/)) {
+		if (token.startsWith("#")) return false;
+		if (token === "--dry-run") return true;
+	}
+	return false;
+}
+
 /** Match a bash command against the guarded npm operations. */
 export function matchBlockedNpmCommand(command: string): BlockedNpmCommand | null {
 	const [publishRule] = RULES;
-	// The dry-run allowance is scoped per invocation: `pnpm publish --dry-run &&
-	// pnpm -F api publish` must still block the second publish.
-	const globalPublish = new RegExp(publishRule.re.source, "g");
-	for (let match = globalPublish.exec(command); match !== null; match = globalPublish.exec(command)) {
-		const tail = command.slice(match.index).split(/[;&|\n]/)[0] ?? "";
-		if (!tail.includes("--dry-run")) return { label: publishRule.label };
+	// The dry-run allowance is scoped to the matched invocation itself and only
+	// honors the exact flag token: env values or comments carrying "--dry-run"
+	// and falsy spellings like "--dry-run=false" do not exempt a real publish.
+	const globalPublish = new RegExp(publishRule.re.source, "gd");
+	for (
+		let match = globalPublish.exec(command);
+		match !== null;
+		match = globalPublish.exec(command)
+	) {
+		const argsStart = match.indices?.[1]?.[1]
+			?? match.index + match[0].lastIndexOf("publish");
+		if (!invocationHasDryRunFlag(command.slice(argsStart))) {
+			return { label: publishRule.label };
+		}
 	}
 	for (const rule of RULES.slice(1)) {
 		if (rule.re.test(command)) return { label: rule.label };

--- a/packages/utils/extensions/npm-publish-guard.ts
+++ b/packages/utils/extensions/npm-publish-guard.ts
@@ -1,0 +1,83 @@
+/**
+ * pi-utils-fradser — npm publish/credential guard.
+ *
+ * Blocks bash tool calls that would run package publishing or npm credential
+ * flows from the agent's non-interactive shell. These commands cannot complete
+ * there: 2FA web-auth exits immediately with EOTP, and dead tokens surface as
+ * masked 404 PUT failures on unpublished packages. The block reason carries
+ * the corrected procedure so the model redirects to the user's own terminal
+ * instead of retrying.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+
+// Command-position anchor shared with validate-commit: the matched verb must
+// sit at a command position (start, after ;/&/|/newline, or after env vars),
+// not anywhere inside a larger string.
+const COMMAND_POS = "(?:^|[;&|\\n])\\s*(?:[A-Za-z_][A-Za-z_0-9]*=[^\\s]*\\s+)*";
+const END = "(?:[;&|\\s]|$)";
+
+interface GuardRule {
+	label: string;
+	re: RegExp;
+}
+
+const RULES: GuardRule[] = [
+	{
+		// Direct publish plus the recursive/workspace forms (`pnpm -r publish`).
+		label: "Package publish",
+		re: new RegExp(
+			`${COMMAND_POS}(?:npm|pnpm|yarn|bun)\\s+(?:-r\\s+|--recursive\\s+)?publish${END}`,
+		),
+	},
+	{
+		label: "npm credential flow",
+		re: new RegExp(`${COMMAND_POS}npm\\s+(?:login|adduser|logout)${END}`),
+	},
+	{
+		label: "npm token mutation",
+		re: new RegExp(`${COMMAND_POS}npm\\s+token\\s+(?:create|revoke|delete)${END}`),
+	},
+];
+
+export interface BlockedNpmCommand {
+	label: string;
+}
+
+/** Match a bash command against the guarded npm operations. */
+export function matchBlockedNpmCommand(command: string): BlockedNpmCommand | null {
+	if (command.includes("--dry-run")) return null;
+	for (const rule of RULES) {
+		if (rule.re.test(command)) return { label: rule.label };
+	}
+	return null;
+}
+
+/** Build the block reason handed back to the model as corrective steering. */
+export function buildBlockReason(label: string, command: string): string {
+	return [
+		`Blocked: ${label} cannot succeed from a non-interactive shell — 2FA web-auth exits immediately with EOTP, and an invalid token surfaces as a masked 404 PUT on unpublished packages.`,
+		"",
+		"Correct procedure (skill: npm-package-first-release):",
+		'1. Verify credentials yourself first: run `npm whoami`. If it fails with E401, ask the user to run `npm login` in their own terminal and wait for their confirmation.',
+		"2. Ask the user to run this exact command in THEIR terminal — the OTP/browser prompt is visible there — and wait for their report:",
+		`    ${command}`,
+		"3. After they confirm success, verify registry state yourself (e.g. curl https://registry.npmjs.org/<pkg>), then continue the flow: `npm trust github <pkg> --file <release-workflow>.yml --repo <owner>/<repo> --allow-publish -y`, then merge the release PR so CI OIDC owns future versions.",
+		"",
+		"Never ask for OTP codes in chat. Never retry this blocked command unmodified.",
+	].join("\n");
+}
+
+export default function registerNpmPublishGuard(pi: ExtensionAPI): void {
+	pi.on("tool_call", async (event, _ctx) => {
+		if (!isToolCallEventType("bash", event)) return;
+		const command = event.input.command || "";
+		const blocked = matchBlockedNpmCommand(command);
+		if (!blocked) return;
+		return {
+			block: true,
+			reason: buildBlockReason(blocked.label, command),
+		};
+	});
+}

--- a/packages/utils/extensions/npm-publish-guard.ts
+++ b/packages/utils/extensions/npm-publish-guard.ts
@@ -18,6 +18,10 @@ import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 const COMMAND_POS = "(?:^|[;&|\\n])\\s*(?:[A-Za-z_][A-Za-z_0-9]*=[^\\s]*\\s+)*";
 const END = "(?:[;&|\\s]|$)";
 
+/** Workspace/filter flags package managers accept before the verb. */
+const PRE_FLAGS =
+	"(?:(?:--filter|--workspace|--since|-F|-w)(?:=[^\\s;&|]+|\\s+[^\\s;&|]+)?\\s+|workspace\\s+[^\\s;&|]+\\s+|-r\\s+|--recursive\\s+)*";
+
 interface GuardRule {
 	label: string;
 	re: RegExp;
@@ -25,11 +29,10 @@ interface GuardRule {
 
 const RULES: GuardRule[] = [
 	{
-		// Direct publish plus the recursive/workspace forms (`pnpm -r publish`).
+		// Direct publish plus recursive/workspace forms (`pnpm -r publish`,
+		// `pnpm --filter web publish`, `yarn workspace web publish`).
 		label: "Package publish",
-		re: new RegExp(
-			`${COMMAND_POS}(?:npm|pnpm|yarn|bun)\\s+(?:-r\\s+|--recursive\\s+)?publish${END}`,
-		),
+		re: new RegExp(`${COMMAND_POS}(?:npm|pnpm|yarn|bun)\\s+${PRE_FLAGS}publish${END}`),
 	},
 	{
 		label: "npm credential flow",
@@ -47,8 +50,15 @@ export interface BlockedNpmCommand {
 
 /** Match a bash command against the guarded npm operations. */
 export function matchBlockedNpmCommand(command: string): BlockedNpmCommand | null {
-	if (command.includes("--dry-run")) return null;
-	for (const rule of RULES) {
+	const [publishRule] = RULES;
+	// The dry-run allowance is scoped per invocation: `pnpm publish --dry-run &&
+	// pnpm -F api publish` must still block the second publish.
+	const globalPublish = new RegExp(publishRule.re.source, "g");
+	for (let match = globalPublish.exec(command); match !== null; match = globalPublish.exec(command)) {
+		const tail = command.slice(match.index).split(/[;&|\n]/)[0] ?? "";
+		if (!tail.includes("--dry-run")) return { label: publishRule.label };
+	}
+	for (const rule of RULES.slice(1)) {
 		if (rule.re.test(command)) return { label: rule.label };
 	}
 	return null;

--- a/packages/utils/features/npm-publish-guard.feature
+++ b/packages/utils/features/npm-publish-guard.feature
@@ -13,14 +13,22 @@ Feature: npm publish and credential guard
 
   Scenario: Recursive and filtered workspace publishes are blocked
     When bash runs "pnpm -r publish", "pnpm --recursive publish",
-      "pnpm --filter web publish", "pnpm --filter=web publish",
-      "pnpm -F api publish", or "yarn workspace web publish"
+      "pnpm recursive publish", "pnpm --filter web publish",
+      "pnpm --filter=web publish", "pnpm -F api publish", or "yarn workspace web publish"
     Then the call is blocked with the publish label
 
   Scenario: Dry-run allowance is scoped to its own invocation
     When bash runs "pnpm publish --dry-run"
     Then the call is allowed
     When bash runs "pnpm publish --dry-run && pnpm -F api publish"
+    Then the call is blocked with the publish label
+
+  Scenario: The dry-run exemption only accepts the exact flag token
+    When bash runs "pnpm -F api publish --dry-run=false"
+    Then the call is blocked with the publish label
+    When bash runs "FOO=--dry-run npm publish"
+    Then the call is blocked with the publish label
+    When bash runs "pnpm -F api publish # --dry-run"
     Then the call is blocked with the publish label
 
   Scenario: Credential and token flows are blocked without exemptions

--- a/packages/utils/features/npm-publish-guard.feature
+++ b/packages/utils/features/npm-publish-guard.feature
@@ -1,0 +1,38 @@
+Feature: npm publish and credential guard
+  The utils package blocks bash tool calls that run package publishing or npm
+  credential flows from the agent's non-interactive shell. These commands cannot
+  complete there (2FA web-auth EOTP, masked 404 PUT on dead tokens), so the
+  guard blocks the call and returns the corrected terminal procedure.
+
+  Background:
+    Given the pi-utils-fradser package is installed
+
+  Scenario: Package publish commands are blocked across managers
+    When bash runs "npm publish", "pnpm publish", "yarn publish", or "bun publish"
+    Then the call is blocked with the publish label
+
+  Scenario: Recursive and filtered workspace publishes are blocked
+    When bash runs "pnpm -r publish", "pnpm --recursive publish",
+      "pnpm --filter web publish", "pnpm --filter=web publish",
+      "pnpm -F api publish", or "yarn workspace web publish"
+    Then the call is blocked with the publish label
+
+  Scenario: Dry-run allowance is scoped to its own invocation
+    When bash runs "pnpm publish --dry-run"
+    Then the call is allowed
+    When bash runs "pnpm publish --dry-run && pnpm -F api publish"
+    Then the call is blocked with the publish label
+
+  Scenario: Credential and token flows are blocked without exemptions
+    When bash runs "npm login", "npm adduser", "npm logout",
+      "npm token create", or "npm token revoke --dry-run"
+    Then the call is blocked
+
+  Scenario: Env-prefixed invocations are blocked too
+    When bash runs "NPM_CONFIG_REGISTRY=https://registry.npmjs.org npm publish"
+    Then the call is blocked with the publish label
+
+  Scenario: Command-position anchoring avoids false positives
+    When bash runs "echo npm login", "cat pnpm-publish-notes.txt",
+      or git commit with message "npm publish"
+    Then the call is allowed

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import registerContinue from "./extensions/continue.ts";
 import registerEffort from "./extensions/effort.ts";
 import registerInit from "./extensions/init.ts";
+import registerNpmPublishGuard from "./extensions/npm-publish-guard.ts";
 import registerSessions from "./extensions/sessions.ts";
 import registerWorktree from "./extensions/worktree.ts";
 import registerWorktreeCompletion from "./extensions/worktree-completion.ts";
@@ -15,4 +16,5 @@ export default function utilsExtension(pi: ExtensionAPI): void {
 	registerWorktree(pi);
 	registerWorktreeCompletion(pi);
 	registerWorktreeSession(pi);
+	registerNpmPublishGuard(pi);
 }

--- a/packages/utils/tests/test_npm_publish_guard.py
+++ b/packages/utils/tests/test_npm_publish_guard.py
@@ -1,0 +1,74 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+UTILS_PKG_DIR = Path(__file__).resolve().parents[1]
+REPO = UTILS_PKG_DIR.parents[1]
+GUARD_EXTENSION = UTILS_PKG_DIR / "extensions" / "npm-publish-guard.ts"
+
+
+def blocked_label(command: str) -> str | None:
+    script = f"""
+import {{ matchBlockedNpmCommand }} from {json.dumps(GUARD_EXTENSION.as_uri())};
+console.log(JSON.stringify(matchBlockedNpmCommand({json.dumps(command)})));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module"],
+        cwd=REPO,
+        input=script,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise AssertionError(f"Node runner failed:\n{result.stderr}")
+    report = json.loads(result.stdout)
+    return report["label"] if report else None
+
+
+class NpmPublishGuardTests(unittest.TestCase):
+    def assertBlocked(self, command: str, label: str) -> None:
+        self.assertEqual(label, blocked_label(command))
+
+    def assertAllowed(self, command: str) -> None:
+        self.assertIsNone(blocked_label(command))
+
+    def test_publish_blocked_across_managers(self) -> None:
+        for command in ("npm publish", "pnpm publish", "yarn publish", "bun publish"):
+            self.assertBlocked(command, "Package publish")
+
+    def test_recursive_and_filtered_publishes_blocked(self) -> None:
+        for command in (
+            "pnpm -r publish",
+            "pnpm --recursive publish",
+            "pnpm --filter web publish",
+            "pnpm --filter=web publish",
+            "pnpm -F api publish",
+            "yarn workspace web publish",
+            "pnpm --filter web --filter api -r publish",
+        ):
+            self.assertBlocked(command, "Package publish")
+
+    def test_dry_run_allowance_is_per_invocation(self) -> None:
+        self.assertAllowed("pnpm publish --dry-run")
+        self.assertBlocked("pnpm publish --dry-run && pnpm -F api publish", "Package publish")
+        self.assertBlocked("pnpm -F api publish; npm publish --dry-run", "Package publish")
+
+    def test_credential_and_token_flows_blocked_without_exemptions(self) -> None:
+        for command in ("npm login", "npm adduser", "npm logout"):
+            self.assertBlocked(command, "npm credential flow")
+        for command in ("npm token create", "npm token revoke", "npm token delete",
+                        "npm token revoke --dry-run"):
+            self.assertBlocked(command, "npm token mutation")
+
+    def test_env_prefixed_invocations_blocked(self) -> None:
+        self.assertBlocked(
+            "NPM_CONFIG_REGISTRY=https://registry.npmjs.org npm publish",
+            "Package publish",
+        )
+
+    def test_command_position_anchoring_avoids_false_positives(self) -> None:
+        self.assertAllowed("echo npm login")
+        self.assertAllowed("cat pnpm-publish-notes.txt")
+        self.assertAllowed('git commit -m "npm publish"')

--- a/packages/utils/tests/test_npm_publish_guard.py
+++ b/packages/utils/tests/test_npm_publish_guard.py
@@ -42,6 +42,7 @@ class NpmPublishGuardTests(unittest.TestCase):
         for command in (
             "pnpm -r publish",
             "pnpm --recursive publish",
+            "pnpm recursive publish",
             "pnpm --filter web publish",
             "pnpm --filter=web publish",
             "pnpm -F api publish",
@@ -52,8 +53,17 @@ class NpmPublishGuardTests(unittest.TestCase):
 
     def test_dry_run_allowance_is_per_invocation(self) -> None:
         self.assertAllowed("pnpm publish --dry-run")
+        self.assertAllowed("pnpm -F api publish --dry-run")
         self.assertBlocked("pnpm publish --dry-run && pnpm -F api publish", "Package publish")
         self.assertBlocked("pnpm -F api publish; npm publish --dry-run", "Package publish")
+
+    def test_dry_run_allowance_resists_injection_vectors(self) -> None:
+        # Env values, trailing comments, and falsy spellings must not exempt a
+        # real publish.
+        self.assertBlocked("FOO=--dry-run npm publish", "Package publish")
+        self.assertBlocked("pnpm -F api publish # --dry-run", "Package publish")
+        self.assertBlocked("pnpm -F api publish --dry-run=false", "Package publish")
+        self.assertBlocked('pnpm -F api publish --tag next # note: --dry-run', "Package publish")
 
     def test_credential_and_token_flows_blocked_without_exemptions(self) -> None:
         for command in ("npm login", "npm adduser", "npm logout"):


### PR DESCRIPTION
## Summary
**Stacked on #26 (wip/utils-worktree-session)** — merge that first; GitHub will retarget this PR to main afterwards.

- New `npm-publish-guard.ts`: blocks bash tool calls that run package publish (`npm|pnpm|yarn|bun publish`, incl. recursive forms), npm credential flows (`login/adduser/logout`), and token mutations. These cannot complete non-interactively (2FA web-auth exits with EOTP; dead tokens surface as masked 404 PUT on unpublished packages). The block reason is corrective steering: verify credentials yourself, ask the user to run the exact command in their terminal, then continue the trust-setup flow — never request OTP in chat, never retry unmodified
- Command-position anchored regexes avoid false positives inside larger strings; `--dry-run` bypasses the guard
- Ships the project-level `.agents/skills/npm-package-first-release/SKILL.md` referenced by the guard's block reason
- Adds the previously missing changeset for the extension

## Affected packages
- `@fradser/pi-utils` (minor via `.changeset/utils-npm-publish-guard.md`)

## Verification
- `python3 -m pytest packages/utils/tests -q`
- `npx tsc --noEmit -p tsconfig.extensions.json`

## Release impact
1 minor changeset included.

## README changes
None (guard is transparent when not triggered).