### PR TITLE
fix(scripts): prevent premature release retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       # changesets. This retry covers versioned packages that are newer than
       # npm after a partial publish or a merged version PR.
       - name: Retry publishing versioned packages
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.changesets.outputs.has-changesets != 'true'
         run: node scripts/publish-release.mjs
         env:
           NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       # changesets. This retry covers versioned packages that are newer than
       # npm after a partial publish or a merged version PR.
       - name: Retry publishing versioned packages
-        if: github.ref == 'refs/heads/main' && steps.changesets.outputs.has-changesets != 'true'
+        if: github.ref == 'refs/heads/main' && steps.changesets.outputs.hasChangesets != 'true'
         run: node scripts/publish-release.mjs
         env:
           NPM_CONFIG_PROVENANCE: "true"

--- a/features/publish-provenance.feature
+++ b/features/publish-provenance.feature
@@ -24,3 +24,9 @@ Feature: Release publishing without local provenance assumptions
     When the Changesets action has no pending changesets
     Then a main-branch publish step still runs the explicit package release script
     And already published versions are skipped safely
+
+  Scenario: The main workflow does not publish the version PR working tree
+    Given the Changesets action found pending changesets and created or updated a version PR
+    When the action leaves the working tree with bumped package versions
+    Then the main-branch retry step is skipped
+    And publication waits for the version PR merge

--- a/features/publish-provenance.feature
+++ b/features/publish-provenance.feature
@@ -30,3 +30,4 @@ Feature: Release publishing without local provenance assumptions
     When the action leaves the working tree with bumped package versions
     Then the main-branch retry step is skipped
     And publication waits for the version PR merge
+    And the retry checks the Changesets action's camelCase `hasChangesets` output

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -32,4 +32,5 @@ def test_workflow_has_a_main_branch_publish_retry() -> None:
 
 def test_workflow_skips_retry_when_changesets_created_a_version_pr() -> None:
     workflow = (REPO / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
-    assert "steps.changesets.outputs.has-changesets != 'true'" in workflow
+    assert "steps.changesets.outputs.hasChangesets != 'true'" in workflow
+    assert "steps.changesets.outputs.has-changesets" not in workflow

--- a/tests/test_publish_release.py
+++ b/tests/test_publish_release.py
@@ -28,3 +28,8 @@ def test_workflow_has_a_main_branch_publish_retry() -> None:
     workflow = (REPO / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     assert "if: github.ref == 'refs/heads/main'" in workflow
     assert "node scripts/publish-release.mjs" in workflow
+
+
+def test_workflow_skips_retry_when_changesets_created_a_version_pr() -> None:
+    workflow = (REPO / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert "steps.changesets.outputs.has-changesets != 'true'" in workflow


### PR DESCRIPTION
## What
Prevent the release workflow from publishing the temporary version-PR working tree before the version PR is merged.

## Why
The Changesets action updates the release PR branch with bumped package versions. The main-branch retry must not publish that temporary tree; it should only retry versions after the version PR has merged into `main`.

## Changes
- Skip the main-branch retry while Changesets reports pending changesets.
- Use the action's camelCase `hasChangesets` output.
- Add BDD coverage and regression tests for the retry condition.

## Review cycle
3 review signals across 1 round, 0 changes adopted after PR creation; all CI checks are green. Full breakdown: https://github.com/FradSer/pi-packages/pull/28#issuecomment-5422507434

## Verification
- `pnpm test` — 428 tests passed.
- `pnpm exec tsc --noEmit -p tsconfig.extensions.json` — passed.
- `python3 -m pytest tests/test_publish_release.py -q` — 5 passed.
- YAML parsing and `git diff --check` — passed.
- npm audit could not complete because the advisory endpoint was unreachable; gitleaks is not installed.
